### PR TITLE
feat: カランメソッド - Q&A反復練習モード

### DIFF
--- a/backend/src/__tests__/callan-progress.test.ts
+++ b/backend/src/__tests__/callan-progress.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app'
+
+const mockQAItem = {
+  id: 'qa-1',
+  question: 'What is this?',
+  answer: 'This is a pen.',
+  order: 1,
+  lessonId: 'lesson-1',
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+}
+
+const mockCallanProgress = {
+  id: 'progress-1',
+  userId: 1,
+  qaItemId: 'qa-1',
+  mode: 'qa',
+  correctCount: 5,
+  totalCount: 10,
+  lastPracticed: new Date('2024-01-15'),
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-15'),
+}
+
+const createMockPrisma = () => ({
+  lesson: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  qAItem: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockImplementation(({ where }) => {
+      if (where.id === 'qa-1') {
+        return Promise.resolve(mockQAItem)
+      }
+      return Promise.resolve(null)
+    }),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    updateMany: vi.fn(),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  callanProgress: {
+    findUnique: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockImplementation(({ data }) => {
+      return Promise.resolve({
+        id: 'new-progress-id',
+        ...data,
+        correctCount: data.isCorrect ? 1 : 0,
+        totalCount: 1,
+        lastPracticed: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    }),
+    update: vi.fn().mockImplementation(({ data }) => {
+      return Promise.resolve({
+        ...mockCallanProgress,
+        ...data,
+        updatedAt: new Date(),
+      })
+    }),
+    upsert: vi.fn().mockImplementation(({ create, update }) => {
+      return Promise.resolve({
+        id: 'progress-id',
+        ...create,
+        correctCount: create.isCorrect ? 1 : 0,
+        totalCount: 1,
+        lastPracticed: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    }),
+  },
+  $transaction: vi.fn().mockImplementation(async (arg) => {
+    if (Array.isArray(arg)) {
+      return Promise.all(arg)
+    }
+    return arg(createMockPrisma())
+  }),
+})
+
+describe('Callan Progress API', () => {
+  let mockPrisma: ReturnType<typeof createMockPrisma>
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    mockPrisma = createMockPrisma()
+    app = createApp(mockPrisma)
+  })
+
+  describe('POST /api/callan/progress', () => {
+    it('records a correct practice result for a new QA item', async () => {
+      const progressData = {
+        userId: 1,
+        qaItemId: 'qa-1',
+        mode: 'qa',
+        isCorrect: true,
+      }
+
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send(progressData)
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('progress')
+      expect(response.body.progress).toHaveProperty('qaItemId', 'qa-1')
+      expect(response.body.progress).toHaveProperty('mode', 'qa')
+    })
+
+    it('records an incorrect practice result', async () => {
+      const progressData = {
+        userId: 1,
+        qaItemId: 'qa-1',
+        mode: 'qa',
+        isCorrect: false,
+      }
+
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send(progressData)
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('progress')
+    })
+
+    it('updates existing progress when practicing again', async () => {
+      mockPrisma.callanProgress.findUnique.mockResolvedValueOnce(mockCallanProgress)
+
+      const progressData = {
+        userId: 1,
+        qaItemId: 'qa-1',
+        mode: 'qa',
+        isCorrect: true,
+      }
+
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send(progressData)
+
+      expect(response.status).toBe(200)
+      expect(mockPrisma.callanProgress.update).toHaveBeenCalled()
+    })
+
+    it('returns 400 when userId is missing', async () => {
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send({ qaItemId: 'qa-1', mode: 'qa', isCorrect: true })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 400 when qaItemId is missing', async () => {
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send({ userId: 1, mode: 'qa', isCorrect: true })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 400 when mode is invalid', async () => {
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send({ userId: 1, qaItemId: 'qa-1', mode: 'invalid', isCorrect: true })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 400 when isCorrect is not a boolean', async () => {
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send({ userId: 1, qaItemId: 'qa-1', mode: 'qa', isCorrect: 'yes' })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 404 when qaItem does not exist', async () => {
+      mockPrisma.qAItem.findUnique.mockResolvedValueOnce(null)
+
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send({ userId: 1, qaItemId: 'non-existent', mode: 'qa', isCorrect: true })
+
+      expect(response.status).toBe(404)
+      expect(response.body).toHaveProperty('error', 'QA item not found')
+    })
+
+    it('accepts shadowing mode', async () => {
+      const progressData = {
+        userId: 1,
+        qaItemId: 'qa-1',
+        mode: 'shadowing',
+        isCorrect: true,
+      }
+
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send(progressData)
+
+      expect(response.status).toBe(200)
+      expect(response.body.progress).toHaveProperty('mode', 'shadowing')
+    })
+
+    it('accepts dictation mode', async () => {
+      const progressData = {
+        userId: 1,
+        qaItemId: 'qa-1',
+        mode: 'dictation',
+        isCorrect: true,
+      }
+
+      const response = await request(app)
+        .post('/api/callan/progress')
+        .send(progressData)
+
+      expect(response.status).toBe(200)
+      expect(response.body.progress).toHaveProperty('mode', 'dictation')
+    })
+  })
+
+  describe('GET /api/callan/progress/:lessonId', () => {
+    it('returns progress for all QA items in a lesson', async () => {
+      const mockProgress = [
+        { ...mockCallanProgress, qaItemId: 'qa-1' },
+        { ...mockCallanProgress, id: 'progress-2', qaItemId: 'qa-2' },
+      ]
+      mockPrisma.callanProgress.findMany.mockResolvedValueOnce(mockProgress)
+
+      const response = await request(app)
+        .get('/api/callan/progress/lesson-1?userId=1')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('progress')
+      expect(Array.isArray(response.body.progress)).toBe(true)
+    })
+
+    it('returns 400 when userId is missing', async () => {
+      const response = await request(app)
+        .get('/api/callan/progress/lesson-1')
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('filters by mode when provided', async () => {
+      const response = await request(app)
+        .get('/api/callan/progress/lesson-1?userId=1&mode=qa')
+
+      expect(response.status).toBe(200)
+      expect(mockPrisma.callanProgress.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            mode: 'qa',
+          }),
+        })
+      )
+    })
+  })
+})

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import progressRouter from './routes/progress';
 import usersRouter from './routes/users';
 import lessonsRouter from './routes/lessons';
 import qaItemsRouter from './routes/qa-items';
+import callanProgressRouter from './routes/callan-progress';
 
 export function createApp(prisma?: unknown) {
   const app = express();
@@ -48,6 +49,7 @@ export function createApp(prisma?: unknown) {
   app.use('/api/users', usersRouter);
   app.use('/api/lessons', lessonsRouter);
   app.use('/api/qa-items', qaItemsRouter);
+  app.use('/api/callan/progress', callanProgressRouter);
 
   // Error handling
   app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/backend/src/routes/callan-progress.ts
+++ b/backend/src/routes/callan-progress.ts
@@ -1,0 +1,127 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const router = Router();
+
+type PrismaLike = Pick<PrismaClient, 'callanProgress' | 'qAItem'>;
+
+const VALID_MODES = ['qa', 'shadowing', 'dictation'] as const;
+type Mode = typeof VALID_MODES[number];
+
+// POST /api/callan/progress - Record practice result
+router.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const prisma = req.app.locals.prisma as PrismaLike;
+    const { userId, qaItemId, mode, isCorrect } = req.body;
+
+    // Validation
+    if (typeof userId !== 'number' || !Number.isInteger(userId)) {
+      return res.status(400).json({ error: 'userId must be an integer' });
+    }
+
+    if (typeof qaItemId !== 'string' || !qaItemId.trim()) {
+      return res.status(400).json({ error: 'qaItemId is required' });
+    }
+
+    if (!VALID_MODES.includes(mode)) {
+      return res.status(400).json({ error: `mode must be one of: ${VALID_MODES.join(', ')}` });
+    }
+
+    if (typeof isCorrect !== 'boolean') {
+      return res.status(400).json({ error: 'isCorrect must be a boolean' });
+    }
+
+    // Check if QA item exists
+    const qaItem = await prisma.qAItem.findUnique({
+      where: { id: qaItemId },
+    });
+
+    if (!qaItem) {
+      return res.status(404).json({ error: 'QA item not found' });
+    }
+
+    // Check for existing progress
+    const existingProgress = await prisma.callanProgress.findUnique({
+      where: {
+        userId_qaItemId_mode: {
+          userId,
+          qaItemId,
+          mode,
+        },
+      },
+    });
+
+    let progress;
+
+    if (existingProgress) {
+      // Update existing progress
+      progress = await prisma.callanProgress.update({
+        where: { id: existingProgress.id },
+        data: {
+          correctCount: existingProgress.correctCount + (isCorrect ? 1 : 0),
+          totalCount: existingProgress.totalCount + 1,
+          lastPracticed: new Date(),
+        },
+      });
+    } else {
+      // Create new progress
+      progress = await prisma.callanProgress.create({
+        data: {
+          userId,
+          qaItemId,
+          mode,
+          correctCount: isCorrect ? 1 : 0,
+          totalCount: 1,
+          lastPracticed: new Date(),
+        },
+      });
+    }
+
+    res.json({ progress });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/callan/progress/:lessonId - Get progress for a lesson
+router.get('/:lessonId', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const prisma = req.app.locals.prisma as PrismaLike;
+    const { lessonId } = req.params;
+    const userId = parseInt(req.query.userId as string, 10);
+    const mode = req.query.mode as Mode | undefined;
+
+    if (isNaN(userId)) {
+      return res.status(400).json({ error: 'userId query parameter is required' });
+    }
+
+    const whereClause: {
+      userId: number;
+      qaItem: { lessonId: string };
+      mode?: Mode;
+    } = {
+      userId,
+      qaItem: { lessonId },
+    };
+
+    if (mode && VALID_MODES.includes(mode)) {
+      whereClause.mode = mode;
+    }
+
+    const progress = await prisma.callanProgress.findMany({
+      where: whereClause,
+      include: {
+        qaItem: true,
+      },
+      orderBy: {
+        qaItem: { order: 'asc' },
+      },
+    });
+
+    res.json({ progress });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Login from './pages/Login';
 import CallanHome from './pages/CallanHome';
 import CallanLessons from './pages/CallanLessons';
 import CallanLessonForm from './pages/CallanLessonForm';
+import CallanPractice from './pages/CallanPractice';
 
 function App() {
   return (
@@ -31,6 +32,7 @@ function App() {
                 <Route path="/callan/lessons" element={<CallanLessons />} />
                 <Route path="/callan/lessons/new" element={<CallanLessonForm />} />
                 <Route path="/callan/lessons/:id/edit" element={<CallanLessonForm />} />
+                <Route path="/callan/practice/:lessonId" element={<CallanPractice />} />
               </Routes>
             </main>
           </div>

--- a/frontend/src/components/CallanQAPractice.tsx
+++ b/frontend/src/components/CallanQAPractice.tsx
@@ -1,0 +1,424 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAudio } from '../hooks/useAudio';
+import { useSpeechRecognition } from '../hooks/useSpeechRecognition';
+import { checkAnswer } from '../utils/answerChecker';
+import { callanProgressApi } from '../services/api';
+import { Button, Card } from './ui';
+import type { QAItem } from '../types';
+
+interface CallanQAPracticeProps {
+  qaItems: QAItem[];
+  userId: number;
+  onComplete: (summary: PracticeSummary) => void;
+}
+
+export interface PracticeSummary {
+  totalItems: number;
+  correctCount: number;
+  incorrectCount: number;
+  skippedCount: number;
+  accuracy: number;
+}
+
+type InputMode = 'voice' | 'text';
+type AnswerState = 'waiting' | 'listening' | 'checking' | 'correct' | 'incorrect';
+
+export function CallanQAPractice({ qaItems, userId, onComplete }: CallanQAPracticeProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [inputMode, setInputMode] = useState<InputMode>('voice');
+  const [answerState, setAnswerState] = useState<AnswerState>('waiting');
+  const [textAnswer, setTextAnswer] = useState('');
+  const [feedback, setFeedback] = useState('');
+  const [similarity, setSimilarity] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [incorrectCount, setIncorrectCount] = useState(0);
+  const [skippedCount, setSkippedCount] = useState(0);
+
+  const { speak, stop: stopSpeaking, isSpeaking, isReady: audioReady } = useAudio();
+  const {
+    transcript,
+    interimTranscript,
+    isListening,
+    isSupported: speechSupported,
+    startListening,
+    stopListening,
+    resetTranscript,
+    error: speechError,
+  } = useSpeechRecognition({ continuous: false });
+
+  const currentItem = qaItems[currentIndex];
+  const isLastItem = currentIndex === qaItems.length - 1;
+  const progress = ((currentIndex + 1) / qaItems.length) * 100;
+
+  // Speak the question when item changes
+  useEffect(() => {
+    if (currentItem && audioReady && answerState === 'waiting') {
+      speak(currentItem.question);
+    }
+  }, [currentItem, audioReady, speak, answerState]);
+
+  // Handle voice recognition result
+  useEffect(() => {
+    if (transcript && answerState === 'listening') {
+      handleAnswerCheck(transcript);
+    }
+  }, [transcript]);
+
+  const handleAnswerCheck = useCallback(
+    async (answer: string) => {
+      if (!currentItem) return;
+
+      setAnswerState('checking');
+      const result = checkAnswer(answer, currentItem.answer);
+
+      setSimilarity(result.similarity);
+      setFeedback(result.feedback);
+      setAnswerState(result.isCorrect ? 'correct' : 'incorrect');
+
+      if (result.isCorrect) {
+        setCorrectCount((prev) => prev + 1);
+      } else {
+        setIncorrectCount((prev) => prev + 1);
+        // Speak the correct answer for incorrect responses
+        setTimeout(() => {
+          speak(currentItem.answer);
+        }, 500);
+      }
+
+      // Record progress
+      try {
+        await callanProgressApi.recordProgress({
+          userId,
+          qaItemId: currentItem.id,
+          mode: 'qa',
+          isCorrect: result.isCorrect,
+        });
+      } catch (err) {
+        console.error('Failed to record progress:', err);
+      }
+    },
+    [currentItem, userId, speak]
+  );
+
+  const handleStartListening = useCallback(() => {
+    stopSpeaking();
+    resetTranscript();
+    setAnswerState('listening');
+    startListening();
+  }, [stopSpeaking, resetTranscript, startListening]);
+
+  const handleStopListening = useCallback(() => {
+    stopListening();
+    if (transcript) {
+      handleAnswerCheck(transcript);
+    } else {
+      setAnswerState('waiting');
+    }
+  }, [stopListening, transcript, handleAnswerCheck]);
+
+  const handleTextSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (textAnswer.trim()) {
+        handleAnswerCheck(textAnswer.trim());
+      }
+    },
+    [textAnswer, handleAnswerCheck]
+  );
+
+  const handleNext = useCallback(() => {
+    if (isLastItem) {
+      const summary: PracticeSummary = {
+        totalItems: qaItems.length,
+        correctCount,
+        incorrectCount,
+        skippedCount,
+        accuracy: (correctCount / qaItems.length) * 100,
+      };
+      onComplete(summary);
+    } else {
+      setCurrentIndex((prev) => prev + 1);
+      setAnswerState('waiting');
+      setTextAnswer('');
+      resetTranscript();
+      setFeedback('');
+      setSimilarity(0);
+    }
+  }, [
+    isLastItem,
+    qaItems.length,
+    correctCount,
+    incorrectCount,
+    skippedCount,
+    onComplete,
+    resetTranscript,
+  ]);
+
+  const handleRetry = useCallback(() => {
+    setAnswerState('waiting');
+    setTextAnswer('');
+    resetTranscript();
+    setFeedback('');
+    setSimilarity(0);
+    speak(currentItem.question);
+  }, [resetTranscript, speak, currentItem]);
+
+  const handleSkip = useCallback(() => {
+    setSkippedCount((prev) => prev + 1);
+    handleNext();
+  }, [handleNext]);
+
+  const handleRepeatQuestion = useCallback(() => {
+    speak(currentItem.question);
+  }, [speak, currentItem]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement) return;
+
+      switch (e.key) {
+        case ' ':
+          e.preventDefault();
+          if (answerState === 'correct' || answerState === 'incorrect') {
+            handleNext();
+          } else if (inputMode === 'voice' && !isListening) {
+            handleStartListening();
+          }
+          break;
+        case 'r':
+        case 'R':
+          if (answerState === 'incorrect') {
+            handleRetry();
+          } else if (answerState === 'waiting') {
+            handleRepeatQuestion();
+          }
+          break;
+        case 's':
+        case 'S':
+          if (answerState === 'waiting' || answerState === 'listening') {
+            handleSkip();
+          }
+          break;
+        case 'Escape':
+          if (isListening) {
+            stopListening();
+            setAnswerState('waiting');
+          }
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [
+    answerState,
+    inputMode,
+    isListening,
+    handleNext,
+    handleRetry,
+    handleRepeatQuestion,
+    handleSkip,
+    handleStartListening,
+    stopListening,
+  ]);
+
+  if (!currentItem) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Progress indicator */}
+      <div className="flex items-center gap-4">
+        <div className="flex-1 bg-surface-elevated rounded-full h-2">
+          <div
+            className="bg-primary h-2 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <span className="text-text-secondary text-sm whitespace-nowrap">
+          {currentIndex + 1} / {qaItems.length}
+        </span>
+      </div>
+
+      {/* Question card */}
+      <Card className="p-6">
+        <div className="flex items-start justify-between gap-4 mb-6">
+          <div className="flex-1">
+            <p className="text-xs text-text-muted uppercase tracking-wide mb-2">
+              Question
+            </p>
+            <p className="text-xl font-medium text-text-primary">
+              {currentItem.question}
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleRepeatQuestion}
+            disabled={isSpeaking}
+          >
+            {isSpeaking ? '🔊 Speaking...' : '🔊 Repeat'}
+          </Button>
+        </div>
+
+        {/* Input mode toggle */}
+        <div className="flex gap-2 mb-4">
+          <Button
+            variant={inputMode === 'voice' ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={() => setInputMode('voice')}
+            disabled={!speechSupported}
+          >
+            🎤 Voice
+          </Button>
+          <Button
+            variant={inputMode === 'text' ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={() => setInputMode('text')}
+          >
+            ⌨️ Text
+          </Button>
+        </div>
+
+        {/* Answer input area */}
+        {inputMode === 'voice' ? (
+          <div className="space-y-4">
+            {!speechSupported && (
+              <p className="text-warning text-sm">
+                Speech recognition is not supported in this browser. Please use text input.
+              </p>
+            )}
+
+            {speechError && (
+              <p className="text-error text-sm">{speechError}</p>
+            )}
+
+            {/* Voice input display */}
+            <div className="bg-surface-elevated rounded-lg p-4 min-h-[80px]">
+              {isListening ? (
+                <div className="flex items-center gap-2">
+                  <span className="animate-pulse text-primary">●</span>
+                  <span className="text-text-secondary">
+                    {interimTranscript || 'Listening...'}
+                  </span>
+                </div>
+              ) : transcript ? (
+                <p className="text-text-primary">{transcript}</p>
+              ) : (
+                <p className="text-text-muted">
+                  Press the microphone button or Space to start speaking
+                </p>
+              )}
+            </div>
+
+            {/* Voice control button */}
+            {answerState === 'waiting' || answerState === 'listening' ? (
+              <Button
+                variant="primary"
+                size="lg"
+                className="w-full"
+                onClick={isListening ? handleStopListening : handleStartListening}
+                disabled={!speechSupported || isSpeaking}
+              >
+                {isListening ? '⏹️ Stop Recording' : '🎤 Start Recording'}
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <form onSubmit={handleTextSubmit} className="space-y-4">
+            <input
+              type="text"
+              value={textAnswer}
+              onChange={(e) => setTextAnswer(e.target.value)}
+              placeholder="Type your answer..."
+              className="w-full px-4 py-3 rounded-lg bg-surface-elevated border border-border text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-primary"
+              disabled={answerState !== 'waiting'}
+              autoFocus
+            />
+            {answerState === 'waiting' && (
+              <Button
+                type="submit"
+                variant="primary"
+                size="lg"
+                className="w-full"
+                disabled={!textAnswer.trim()}
+              >
+                Submit Answer
+              </Button>
+            )}
+          </form>
+        )}
+      </Card>
+
+      {/* Feedback card */}
+      {(answerState === 'correct' || answerState === 'incorrect') && (
+        <Card
+          className={`p-6 ${
+            answerState === 'correct'
+              ? 'border-success bg-success/10'
+              : 'border-error bg-error/10'
+          }`}
+        >
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-2xl">
+              {answerState === 'correct' ? '✅' : '❌'}
+            </span>
+            <span
+              className={`text-lg font-semibold ${
+                answerState === 'correct' ? 'text-success' : 'text-error'
+              }`}
+            >
+              {answerState === 'correct' ? 'Correct!' : 'Not quite...'}
+            </span>
+            <span className="text-text-muted text-sm ml-auto">
+              {Math.round(similarity * 100)}% match
+            </span>
+          </div>
+
+          <p className="text-text-secondary mb-4">{feedback}</p>
+
+          {answerState === 'incorrect' && (
+            <div className="bg-surface rounded-lg p-4 mb-4">
+              <p className="text-xs text-text-muted uppercase tracking-wide mb-1">
+                Correct Answer
+              </p>
+              <p className="text-text-primary font-medium">{currentItem.answer}</p>
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            {answerState === 'incorrect' && (
+              <Button variant="secondary" onClick={handleRetry}>
+                Retry (R)
+              </Button>
+            )}
+            <Button variant="primary" onClick={handleNext}>
+              {isLastItem ? 'Finish' : 'Next'} (Space)
+            </Button>
+          </div>
+        </Card>
+      )}
+
+      {/* Skip button */}
+      {(answerState === 'waiting' || answerState === 'listening') && (
+        <div className="flex justify-center">
+          <Button variant="secondary" size="sm" onClick={handleSkip}>
+            Skip (S)
+          </Button>
+        </div>
+      )}
+
+      {/* Keyboard shortcuts hint */}
+      <div className="text-center text-text-muted text-xs">
+        <span>Shortcuts: </span>
+        <span className="mx-1">Space = Record/Next</span>
+        <span className="mx-1">R = Retry/Repeat</span>
+        <span className="mx-1">S = Skip</span>
+      </div>
+    </div>
+  );
+}
+
+export default CallanQAPractice;

--- a/frontend/src/hooks/useSpeechRecognition.test.ts
+++ b/frontend/src/hooks/useSpeechRecognition.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSpeechRecognition } from './useSpeechRecognition';
+
+// Store instance reference for tests
+let currentMockInstance: MockSpeechRecognition | null = null;
+
+// Mock SpeechRecognition
+class MockSpeechRecognition {
+  continuous = false;
+  interimResults = false;
+  lang = 'en-US';
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onresult: ((event: { results: SpeechRecognitionResultList }) => void) | null = null;
+  onerror: ((event: { error: string }) => void) | null = null;
+
+  constructor() {
+    currentMockInstance = this;
+  }
+
+  start = vi.fn().mockImplementation(() => {
+    setTimeout(() => this.onstart?.(), 0);
+  });
+
+  stop = vi.fn().mockImplementation(() => {
+    setTimeout(() => this.onend?.(), 0);
+  });
+
+  abort = vi.fn();
+
+  simulateResult(transcript: string, isFinal: boolean) {
+    const mockResult = {
+      length: 1,
+      0: {
+        isFinal,
+        length: 1,
+        0: { transcript, confidence: 0.9 },
+      },
+    };
+    this.onresult?.({ results: mockResult as unknown as SpeechRecognitionResultList });
+  }
+
+  simulateError(error: string) {
+    this.onerror?.({ error });
+  }
+}
+
+describe('useSpeechRecognition', () => {
+  beforeEach(() => {
+    currentMockInstance = null;
+    
+    // Set up the global mock as a class
+    (globalThis as unknown as { SpeechRecognition: typeof MockSpeechRecognition }).SpeechRecognition = MockSpeechRecognition;
+    (globalThis as unknown as { webkitSpeechRecognition: typeof MockSpeechRecognition }).webkitSpeechRecognition = MockSpeechRecognition;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    currentMockInstance = null;
+    delete (globalThis as Record<string, unknown>).SpeechRecognition;
+    delete (globalThis as Record<string, unknown>).webkitSpeechRecognition;
+  });
+
+  it('should return initial state', () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    expect(result.current.transcript).toBe('');
+    expect(result.current.isListening).toBe(false);
+    expect(result.current.isSupported).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should start listening when startListening is called', async () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(true);
+    });
+    expect(currentMockInstance?.start).toHaveBeenCalled();
+  });
+
+  it('should stop listening when stopListening is called', async () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(true);
+    });
+
+    act(() => {
+      result.current.stopListening();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(false);
+    });
+    expect(currentMockInstance?.stop).toHaveBeenCalled();
+  });
+
+  it('should update transcript when speech is recognized', async () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(true);
+    });
+
+    act(() => {
+      currentMockInstance?.simulateResult('hello world', true);
+    });
+
+    expect(result.current.transcript).toBe('hello world');
+  });
+
+  it('should update interim transcript for non-final results', async () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(true);
+    });
+
+    act(() => {
+      currentMockInstance?.simulateResult('hel', false);
+    });
+
+    expect(result.current.interimTranscript).toBe('hel');
+  });
+
+  it('should reset transcript when resetTranscript is called', async () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(true);
+    });
+
+    act(() => {
+      currentMockInstance?.simulateResult('hello world', true);
+    });
+
+    expect(result.current.transcript).toBe('hello world');
+
+    act(() => {
+      result.current.resetTranscript();
+    });
+
+    expect(result.current.transcript).toBe('');
+  });
+
+  it('should handle errors', async () => {
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isListening).toBe(true);
+    });
+
+    act(() => {
+      currentMockInstance?.simulateError('no-speech');
+    });
+
+    expect(result.current.error).toBe('no-speech');
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it('should indicate unsupported when SpeechRecognition is not available', () => {
+    delete (globalThis as Record<string, unknown>).SpeechRecognition;
+    delete (globalThis as Record<string, unknown>).webkitSpeechRecognition;
+
+    const { result } = renderHook(() => useSpeechRecognition());
+
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it('should accept language option', () => {
+    renderHook(() => useSpeechRecognition({ language: 'ja-JP' }));
+
+    expect(currentMockInstance?.lang).toBe('ja-JP');
+  });
+
+  it('should accept continuous option', () => {
+    renderHook(() => useSpeechRecognition({ continuous: true }));
+
+    expect(currentMockInstance?.continuous).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useSpeechRecognition.ts
+++ b/frontend/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseSpeechRecognitionOptions {
+  language?: string;
+  continuous?: boolean;
+  interimResults?: boolean;
+}
+
+interface UseSpeechRecognitionReturn {
+  transcript: string;
+  interimTranscript: string;
+  isListening: boolean;
+  isSupported: boolean;
+  error: string | null;
+  startListening: () => void;
+  stopListening: () => void;
+  resetTranscript: () => void;
+}
+
+// Type definitions for Web Speech API
+interface SpeechRecognitionEvent {
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionResultList {
+  length: number;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+  isFinal: boolean;
+  length: number;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognitionErrorEvent {
+  error: string;
+}
+
+interface SpeechRecognitionInstance {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onstart: (() => void) | null;
+  onend: (() => void) | null;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionInstance;
+
+const getSpeechRecognition = (): SpeechRecognitionConstructor | null => {
+  if (typeof window === 'undefined') return null;
+  
+  return (
+    (window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor }).SpeechRecognition ||
+    (window as unknown as { webkitSpeechRecognition?: SpeechRecognitionConstructor }).webkitSpeechRecognition ||
+    null
+  );
+};
+
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions = {}
+): UseSpeechRecognitionReturn {
+  const { language = 'en-US', continuous = false, interimResults = true } = options;
+
+  const [transcript, setTranscript] = useState('');
+  const [interimTranscript, setInterimTranscript] = useState('');
+  const [isListening, setIsListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const SpeechRecognitionClass = getSpeechRecognition();
+  const isSupported = SpeechRecognitionClass !== null;
+
+  // Initialize recognition instance
+  useEffect(() => {
+    if (!SpeechRecognitionClass) return;
+
+    const recognition = new SpeechRecognitionClass();
+    recognition.continuous = continuous;
+    recognition.interimResults = interimResults;
+    recognition.lang = language;
+
+    recognition.onstart = () => {
+      setIsListening(true);
+      setError(null);
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+    };
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let finalTranscript = '';
+      let interim = '';
+
+      for (let i = 0; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          finalTranscript += result[0].transcript;
+        } else {
+          interim += result[0].transcript;
+        }
+      }
+
+      if (finalTranscript) {
+        setTranscript((prev) => prev + finalTranscript);
+      }
+      setInterimTranscript(interim);
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      setError(event.error);
+      setIsListening(false);
+    };
+
+    recognitionRef.current = recognition;
+
+    return () => {
+      if (recognitionRef.current) {
+        recognitionRef.current.abort();
+      }
+    };
+  }, [SpeechRecognitionClass, continuous, interimResults, language]);
+
+  const startListening = useCallback(() => {
+    if (!recognitionRef.current) return;
+
+    setError(null);
+    try {
+      recognitionRef.current.start();
+    } catch (err) {
+      // Recognition might already be started
+      if (err instanceof Error && !err.message.includes('already started')) {
+        setError(err.message);
+      }
+    }
+  }, []);
+
+  const stopListening = useCallback(() => {
+    if (!recognitionRef.current) return;
+
+    try {
+      recognitionRef.current.stop();
+    } catch {
+      // Ignore errors when stopping
+    }
+  }, []);
+
+  const resetTranscript = useCallback(() => {
+    setTranscript('');
+    setInterimTranscript('');
+  }, []);
+
+  return {
+    transcript,
+    interimTranscript,
+    isListening,
+    isSupported,
+    error,
+    startListening,
+    stopListening,
+    resetTranscript,
+  };
+}
+
+export default useSpeechRecognition;

--- a/frontend/src/pages/CallanLessons.tsx
+++ b/frontend/src/pages/CallanLessons.tsx
@@ -122,6 +122,11 @@ export function CallanLessons() {
                 </p>
               </div>
               <div className="flex gap-2">
+                {lesson.qaItems.length > 0 && (
+                  <Link to={`/callan/practice/${lesson.id}`}>
+                    <Button variant="primary" size="sm">Practice</Button>
+                  </Link>
+                )}
                 <Link to={`/callan/lessons/${lesson.id}/edit`}>
                   <Button variant="secondary" size="sm">Edit</Button>
                 </Link>

--- a/frontend/src/pages/CallanPractice.tsx
+++ b/frontend/src/pages/CallanPractice.tsx
@@ -1,0 +1,289 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { lessonsApi } from '../services/api';
+import { useUser } from '../context/UserContext';
+import { Container, Card, Button } from '../components/ui';
+import { CallanQAPractice, type PracticeSummary } from '../components/CallanQAPractice';
+import type { Lesson } from '../types';
+
+type PracticeState = 'loading' | 'ready' | 'practicing' | 'completed' | 'error';
+
+export function CallanPractice() {
+  const { lessonId } = useParams<{ lessonId: string }>();
+  const { user } = useUser();
+
+  const [lesson, setLesson] = useState<Lesson | null>(null);
+  const [practiceState, setPracticeState] = useState<PracticeState>('loading');
+  const [error, setError] = useState<string | null>(null);
+  const [summary, setSummary] = useState<PracticeSummary | null>(null);
+
+  const fetchLesson = useCallback(async () => {
+    if (!lessonId) return;
+
+    setPracticeState('loading');
+    setError(null);
+
+    try {
+      const { lesson: fetchedLesson } = await lessonsApi.getById(lessonId);
+      setLesson(fetchedLesson);
+      setPracticeState('ready');
+    } catch (err) {
+      console.error('Error fetching lesson:', err);
+      setError('Failed to load lesson');
+      setPracticeState('error');
+    }
+  }, [lessonId]);
+
+  useEffect(() => {
+    fetchLesson();
+  }, [fetchLesson]);
+
+  const handleStartPractice = useCallback(() => {
+    setPracticeState('practicing');
+  }, []);
+
+  const handleComplete = useCallback((practiceSummary: PracticeSummary) => {
+    setSummary(practiceSummary);
+    setPracticeState('completed');
+  }, []);
+
+  const handlePracticeAgain = useCallback(() => {
+    setSummary(null);
+    setPracticeState('ready');
+  }, []);
+
+  if (!user) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h2 className="text-2xl font-bold text-text-primary mb-4">
+            Please log in to practice
+          </h2>
+          <Link to="/login">
+            <Button variant="primary">Go to Login</Button>
+          </Link>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (practiceState === 'loading') {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <div className="text-text-muted animate-pulse">Loading lesson...</div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (practiceState === 'error' || !lesson) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h2 className="text-xl font-semibold text-error mb-4">
+            {error || 'Lesson not found'}
+          </h2>
+          <Link to="/callan/lessons">
+            <Button variant="secondary">Back to Lessons</Button>
+          </Link>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (lesson.qaItems.length === 0) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h2 className="text-xl font-semibold text-text-primary mb-4">
+            No Q&A items in this lesson
+          </h2>
+          <p className="text-text-secondary mb-6">
+            Add some Q&A items to start practicing.
+          </p>
+          <div className="flex gap-4 justify-center">
+            <Link to={`/callan/lessons/${lesson.id}/edit`}>
+              <Button variant="primary">Edit Lesson</Button>
+            </Link>
+            <Link to="/callan/lessons">
+              <Button variant="secondary">Back to Lessons</Button>
+            </Link>
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (practiceState === 'ready') {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h1 className="text-3xl font-bold text-text-primary mb-4">
+            {lesson.title}
+          </h1>
+          {lesson.description && (
+            <p className="text-text-secondary mb-6">{lesson.description}</p>
+          )}
+
+          <div className="bg-surface-elevated rounded-lg p-6 mb-8 max-w-md mx-auto">
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Practice Info
+            </h2>
+            <div className="space-y-2 text-left">
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Q&A Items:</span>
+                <span className="text-text-primary font-medium">
+                  {lesson.qaItems.length}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Mode:</span>
+                <span className="text-text-primary font-medium">
+                  Q&A Practice
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <Button
+              variant="primary"
+              size="lg"
+              className="w-full max-w-xs"
+              onClick={handleStartPractice}
+            >
+              Start Practice
+            </Button>
+
+            <div>
+              <Link to="/callan/lessons">
+                <Button variant="secondary" size="sm">
+                  Back to Lessons
+                </Button>
+              </Link>
+            </div>
+          </div>
+
+          <div className="mt-8 text-text-muted text-sm">
+            <p>Tips:</p>
+            <ul className="list-disc list-inside text-left max-w-md mx-auto mt-2 space-y-1">
+              <li>Listen to the question carefully</li>
+              <li>Speak your answer clearly</li>
+              <li>You can also type if voice input doesn't work</li>
+              <li>Use keyboard shortcuts for faster navigation</li>
+            </ul>
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (practiceState === 'completed' && summary) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h1 className="text-3xl font-bold text-text-primary mb-2">
+            Practice Complete!
+          </h1>
+          <p className="text-text-secondary mb-8">{lesson.title}</p>
+
+          <div className="bg-surface-elevated rounded-lg p-6 mb-8 max-w-md mx-auto">
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Your Results
+            </h2>
+            <div className="space-y-3">
+              <div className="flex justify-between items-center">
+                <span className="text-text-secondary">Accuracy:</span>
+                <span
+                  className={`text-2xl font-bold ${
+                    summary.accuracy >= 80
+                      ? 'text-success'
+                      : summary.accuracy >= 60
+                      ? 'text-warning'
+                      : 'text-error'
+                  }`}
+                >
+                  {Math.round(summary.accuracy)}%
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Total Items:</span>
+                <span className="text-text-primary font-medium">
+                  {summary.totalItems}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Correct:</span>
+                <span className="text-success font-medium">
+                  {summary.correctCount}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Incorrect:</span>
+                <span className="text-error font-medium">
+                  {summary.incorrectCount}
+                </span>
+              </div>
+              {summary.skippedCount > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-text-secondary">Skipped:</span>
+                  <span className="text-warning font-medium">
+                    {summary.skippedCount}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Encouragement message */}
+          <p className="text-text-secondary mb-8">
+            {summary.accuracy >= 80
+              ? '🎉 Excellent work! Keep it up!'
+              : summary.accuracy >= 60
+              ? '👍 Good effort! Practice makes perfect.'
+              : '💪 Keep practicing! You\'ll get better each time.'}
+          </p>
+
+          <div className="flex gap-4 justify-center flex-wrap">
+            <Button variant="primary" onClick={handlePracticeAgain}>
+              Practice Again
+            </Button>
+            <Link to="/callan/lessons">
+              <Button variant="secondary">Back to Lessons</Button>
+            </Link>
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  // Practicing state
+  return (
+    <Container size="lg" className="py-10">
+      <header className="mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-text-primary">
+              {lesson.title}
+            </h1>
+            <p className="text-text-secondary text-sm">Q&A Practice Mode</p>
+          </div>
+          <Link to="/callan/lessons">
+            <Button variant="secondary" size="sm">
+              Exit Practice
+            </Button>
+          </Link>
+        </div>
+      </header>
+
+      <CallanQAPractice
+        qaItems={lesson.qaItems}
+        userId={user.id}
+        onComplete={handleComplete}
+      />
+    </Container>
+  );
+}
+
+export default CallanPractice;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { Word, User, Progress, Statistics, DailyStats, Lesson, QAItem } from '../types';
+import type { Word, User, Progress, Statistics, DailyStats, Lesson, QAItem, CallanProgress } from '../types';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
 
@@ -160,6 +160,30 @@ export const qaItemsApi = {
 
   reorder: async (lessonId: string, items: { id: string; order: number }[]) => {
     const response = await api.put<{ message: string }>(`/lessons/${lessonId}/qa-items/reorder`, { items });
+    return response.data;
+  },
+};
+
+// Callan Progress API
+export const callanProgressApi = {
+  recordProgress: async (data: {
+    userId: number;
+    qaItemId: string;
+    mode: 'qa' | 'shadowing' | 'dictation';
+    isCorrect: boolean;
+  }) => {
+    const response = await api.post<{ progress: CallanProgress }>('/callan/progress', data);
+    return response.data;
+  },
+
+  getLessonProgress: async (lessonId: string, userId: number, mode?: 'qa' | 'shadowing' | 'dictation') => {
+    const params = new URLSearchParams({ userId: userId.toString() });
+    if (mode) {
+      params.append('mode', mode);
+    }
+    const response = await api.get<{ progress: CallanProgress[] }>(
+      `/callan/progress/${lessonId}?${params.toString()}`
+    );
     return response.data;
   },
 };

--- a/frontend/src/utils/answerChecker.test.ts
+++ b/frontend/src/utils/answerChecker.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { checkAnswer, normalizeText, calculateSimilarity } from './answerChecker';
+
+describe('normalizeText', () => {
+  it('should convert to lowercase', () => {
+    expect(normalizeText('Hello World')).toBe('hello world');
+  });
+
+  it('should remove punctuation', () => {
+    expect(normalizeText('Hello, World!')).toBe('hello world');
+    expect(normalizeText("It's a test.")).toBe('its a test');
+  });
+
+  it('should trim whitespace', () => {
+    expect(normalizeText('  hello  world  ')).toBe('hello world');
+  });
+
+  it('should handle multiple spaces', () => {
+    expect(normalizeText('hello    world')).toBe('hello world');
+  });
+
+  it('should handle empty string', () => {
+    expect(normalizeText('')).toBe('');
+  });
+});
+
+describe('calculateSimilarity', () => {
+  it('should return 1 for identical strings', () => {
+    expect(calculateSimilarity('hello', 'hello')).toBe(1);
+  });
+
+  it('should return 0 for completely different strings', () => {
+    expect(calculateSimilarity('abc', 'xyz')).toBe(0);
+  });
+
+  it('should return a value between 0 and 1 for similar strings', () => {
+    const similarity = calculateSimilarity('hello', 'hallo');
+    expect(similarity).toBeGreaterThan(0);
+    expect(similarity).toBeLessThan(1);
+  });
+
+  it('should be case insensitive after normalization', () => {
+    expect(calculateSimilarity('hello', 'HELLO')).toBe(1);
+  });
+
+  it('should handle empty strings', () => {
+    expect(calculateSimilarity('', '')).toBe(1);
+    expect(calculateSimilarity('hello', '')).toBe(0);
+    expect(calculateSimilarity('', 'hello')).toBe(0);
+  });
+});
+
+describe('checkAnswer', () => {
+  it('should return correct for exact match', () => {
+    const result = checkAnswer('This is a pen', 'This is a pen');
+    expect(result.isCorrect).toBe(true);
+    expect(result.similarity).toBe(1);
+  });
+
+  it('should return correct for case-insensitive match', () => {
+    const result = checkAnswer('this is a pen', 'This is a Pen');
+    expect(result.isCorrect).toBe(true);
+    expect(result.similarity).toBe(1);
+  });
+
+  it('should return correct for match with different punctuation', () => {
+    const result = checkAnswer('This is a pen!', 'This is a pen.');
+    expect(result.isCorrect).toBe(true);
+    expect(result.similarity).toBe(1);
+  });
+
+  it('should return correct for similarity above threshold', () => {
+    // "This is a pen" vs "This is a pen" with minor typo
+    const result = checkAnswer('This is a pen', 'This is a pem');
+    expect(result.isCorrect).toBe(true);
+    expect(result.similarity).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('should return incorrect for low similarity', () => {
+    const result = checkAnswer('completely different answer', 'This is a pen');
+    expect(result.isCorrect).toBe(false);
+    expect(result.similarity).toBeLessThan(0.8);
+  });
+
+  it('should accept custom threshold', () => {
+    const result = checkAnswer('This is a pen', 'This is a pem', 0.95);
+    expect(result.isCorrect).toBe(false);
+  });
+
+  it('should provide appropriate feedback for correct answers', () => {
+    const result = checkAnswer('This is a pen', 'This is a pen');
+    expect(result.feedback).toContain('Correct');
+  });
+
+  it('should provide appropriate feedback for almost correct answers', () => {
+    const result = checkAnswer('This is a pen', 'This is a pem');
+    expect(result.feedback).toBeDefined();
+  });
+
+  it('should provide appropriate feedback for incorrect answers', () => {
+    const result = checkAnswer('wrong answer', 'This is a pen');
+    expect(result.feedback).toBeDefined();
+  });
+
+  it('should handle contractions', () => {
+    const result = checkAnswer("It's a book", "its a book");
+    expect(result.isCorrect).toBe(true);
+  });
+
+  it('should handle articles with minor differences', () => {
+    const result = checkAnswer('the book', 'a book');
+    expect(result.similarity).toBeLessThan(1);
+  });
+});

--- a/frontend/src/utils/answerChecker.ts
+++ b/frontend/src/utils/answerChecker.ts
@@ -1,0 +1,127 @@
+export interface CheckAnswerResult {
+  isCorrect: boolean;
+  similarity: number;
+  feedback: string;
+}
+
+/**
+ * Normalizes text for comparison by:
+ * - Converting to lowercase
+ * - Removing punctuation
+ * - Trimming whitespace
+ * - Collapsing multiple spaces
+ */
+export function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '') // Remove punctuation
+    .replace(/\s+/g, ' ') // Collapse multiple spaces
+    .trim();
+}
+
+/**
+ * Calculates the Levenshtein distance between two strings.
+ * This is the minimum number of single-character edits needed
+ * to transform one string into another.
+ */
+function levenshteinDistance(str1: string, str2: string): number {
+  const m = str1.length;
+  const n = str2.length;
+
+  // Create a 2D array for dynamic programming
+  const dp: number[][] = Array(m + 1)
+    .fill(null)
+    .map(() => Array(n + 1).fill(0));
+
+  // Initialize base cases
+  for (let i = 0; i <= m; i++) {
+    dp[i][0] = i;
+  }
+  for (let j = 0; j <= n; j++) {
+    dp[0][j] = j;
+  }
+
+  // Fill the DP table
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (str1[i - 1] === str2[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1];
+      } else {
+        dp[i][j] = 1 + Math.min(
+          dp[i - 1][j],     // deletion
+          dp[i][j - 1],     // insertion
+          dp[i - 1][j - 1]  // substitution
+        );
+      }
+    }
+  }
+
+  return dp[m][n];
+}
+
+/**
+ * Calculates the similarity between two strings as a value between 0 and 1.
+ * Uses normalized Levenshtein distance.
+ */
+export function calculateSimilarity(str1: string, str2: string): number {
+  const normalized1 = normalizeText(str1);
+  const normalized2 = normalizeText(str2);
+
+  if (normalized1 === normalized2) {
+    return 1;
+  }
+
+  if (normalized1.length === 0 && normalized2.length === 0) {
+    return 1;
+  }
+
+  if (normalized1.length === 0 || normalized2.length === 0) {
+    return 0;
+  }
+
+  const distance = levenshteinDistance(normalized1, normalized2);
+  const maxLength = Math.max(normalized1.length, normalized2.length);
+  
+  return 1 - distance / maxLength;
+}
+
+/**
+ * Checks a user's answer against the correct answer and provides feedback.
+ * 
+ * @param userAnswer - The user's submitted answer
+ * @param correctAnswer - The correct answer to compare against
+ * @param threshold - Minimum similarity (0-1) to consider correct (default: 0.8)
+ * @returns Object with isCorrect, similarity score, and feedback message
+ */
+export function checkAnswer(
+  userAnswer: string,
+  correctAnswer: string,
+  threshold = 0.8
+): CheckAnswerResult {
+  const similarity = calculateSimilarity(userAnswer, correctAnswer);
+  const isCorrect = similarity >= threshold;
+
+  let feedback: string;
+
+  if (similarity === 1) {
+    feedback = 'Correct! Perfect answer!';
+  } else if (similarity >= 0.95) {
+    feedback = 'Correct! Almost perfect!';
+  } else if (similarity >= threshold) {
+    feedback = 'Correct! Good job, but watch for small errors.';
+  } else if (similarity >= 0.6) {
+    feedback = 'Close! Try again. Check your pronunciation and word order.';
+  } else if (similarity >= 0.3) {
+    feedback = 'Not quite. Listen to the question again and try once more.';
+  } else {
+    feedback = 'Try again. Listen carefully to the correct answer.';
+  }
+
+  return {
+    isCorrect,
+    similarity,
+    feedback,
+  };
+}
+
+export default checkAnswer;


### PR DESCRIPTION
## Summary
- カランメソッドの核心である「Q&A反復練習モード」を実装
- 質問を聞いて即座に回答を発話し、正誤判定を受けるフローを構築
- 音声入力・テキスト入力の両方に対応

## 実装内容

### Backend
- `POST /api/callan/progress` - 練習結果を記録するAPI
- `GET /api/callan/progress/:lessonId` - レッスン別の進捗取得API

### Frontend
- `useSpeechRecognition` hook - Web Speech APIを使用した音声認識
- `answerChecker` utility - Levenshtein距離を使用した類似度判定（80%以上で正解）
- `CallanQAPractice` component - メイン練習コンポーネント
- `CallanPractice` page - 練習画面（開始→練習→結果サマリー）

### 機能
- 質問のTTS読み上げ
- 音声認識での回答入力（テキスト入力も可）
- リアルタイム認識テキスト表示
- 正誤判定とフィードバック表示
- 不正解時の正解表示・読み上げ
- スキップ/リトライボタン
- キーボードショートカット（Space=録音/次へ、R=リトライ/繰り返し、S=スキップ）
- 練習終了時のサマリー表示

## Test plan
- [x] Backend: CallanProgress APIのテスト（13 tests pass）
- [x] Frontend: useSpeechRecognitionのテスト（10 tests pass）
- [x] Frontend: answerCheckerのテスト（21 tests pass）
- [x] TypeScript build成功
- [ ] ブラウザでの動作確認（音声認識、TTS、練習フロー）

## 関連Issue
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)