### PR TITLE
feat: add sound change listening practice (#29)

### DIFF
--- a/backend/src/__tests__/sound-changes.test.ts
+++ b/backend/src/__tests__/sound-changes.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app'
+
+const mockCategory = {
+  id: 'cat-1',
+  name: 'Linking',
+  nameJa: '連結',
+  slug: 'linking',
+  description: 'When words connect together smoothly',
+  order: 1,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+}
+
+const mockExercise = {
+  id: 'ex-1',
+  categoryId: 'cat-1',
+  title: 'Basic Linking Practice',
+  difficulty: 'beginner',
+  order: 1,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+}
+
+const mockItem = {
+  id: 'item-1',
+  exerciseId: 'ex-1',
+  type: 'fill_blank',
+  audioPath: '/audio/sound-changes/linking/01-001.mp3',
+  sentence: 'Can I pick it up?',
+  blank: 'pick it',
+  blankIndex: 2,
+  explanation: "'pick it' links as 'pi-kit'",
+  order: 1,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+}
+
+const mockProgress = {
+  id: 'progress-1',
+  userId: 1,
+  itemId: 'item-1',
+  accuracy: 100,
+  isCorrect: true,
+  answeredAt: new Date('2024-01-15'),
+}
+
+const createMockPrisma = () => ({
+  soundChangeCategory: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    findFirst: vi.fn().mockResolvedValue(null),
+  },
+  soundChangeExercise: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+  },
+  soundChangeExerciseItem: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+  },
+  soundChangeProgress: {
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn().mockImplementation(({ data }) => {
+      return Promise.resolve({
+        id: 'new-progress-id',
+        ...data,
+        answeredAt: new Date(),
+      })
+    }),
+  },
+  // Include existing models so app.ts doesn't break
+  lesson: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  qAItem: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    updateMany: vi.fn(),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  callanProgress: {
+    findUnique: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+  },
+  listeningPassage: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+  },
+  listeningQuestion: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+  },
+  listeningProgress: {
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+  },
+  $transaction: vi.fn().mockImplementation(async (arg) => {
+    if (Array.isArray(arg)) {
+      return Promise.all(arg)
+    }
+    return arg(createMockPrisma())
+  }),
+})
+
+describe('Sound Changes API', () => {
+  let mockPrisma: ReturnType<typeof createMockPrisma>
+  let app: ReturnType<typeof createApp>
+
+  beforeEach(() => {
+    mockPrisma = createMockPrisma()
+    app = createApp(mockPrisma)
+  })
+
+  describe('GET /api/sound-changes/categories', () => {
+    it('returns all categories with exercise counts', async () => {
+      const categories = [
+        { ...mockCategory, exercises: [{ id: 'ex-1' }, { id: 'ex-2' }] },
+        { ...mockCategory, id: 'cat-2', name: 'Elision', slug: 'elision', order: 2, exercises: [{ id: 'ex-3' }] },
+      ]
+      mockPrisma.soundChangeCategory.findMany.mockResolvedValueOnce(categories)
+
+      const response = await request(app).get('/api/sound-changes/categories')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('categories')
+      expect(response.body.categories).toHaveLength(2)
+    })
+
+    it('returns categories ordered by order field', async () => {
+      mockPrisma.soundChangeCategory.findMany.mockResolvedValueOnce([])
+
+      await request(app).get('/api/sound-changes/categories')
+
+      expect(mockPrisma.soundChangeCategory.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { order: 'asc' },
+        })
+      )
+    })
+  })
+
+  describe('GET /api/sound-changes/categories/:slug', () => {
+    it('returns a category with its exercises', async () => {
+      const categoryWithExercises = {
+        ...mockCategory,
+        exercises: [{ ...mockExercise, items: [{ id: 'item-1' }] }],
+      }
+      mockPrisma.soundChangeCategory.findFirst.mockResolvedValueOnce(categoryWithExercises)
+
+      const response = await request(app).get('/api/sound-changes/categories/linking')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('category')
+      expect(response.body.category).toHaveProperty('name', 'Linking')
+      expect(response.body.category.exercises).toHaveLength(1)
+    })
+
+    it('returns 404 when category not found', async () => {
+      mockPrisma.soundChangeCategory.findFirst.mockResolvedValueOnce(null)
+
+      const response = await request(app).get('/api/sound-changes/categories/non-existent')
+
+      expect(response.status).toBe(404)
+      expect(response.body).toHaveProperty('error', 'Category not found')
+    })
+  })
+
+  describe('GET /api/sound-changes/exercises/:id', () => {
+    it('returns an exercise with all items', async () => {
+      const exerciseWithItems = {
+        ...mockExercise,
+        category: { name: 'Linking', nameJa: '連結', slug: 'linking' },
+        items: [mockItem],
+      }
+      mockPrisma.soundChangeExercise.findUnique.mockResolvedValueOnce(exerciseWithItems)
+
+      const response = await request(app).get('/api/sound-changes/exercises/ex-1')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('exercise')
+      expect(response.body.exercise).toHaveProperty('title', 'Basic Linking Practice')
+      expect(response.body.exercise.items).toHaveLength(1)
+      expect(response.body.exercise.category).toHaveProperty('slug', 'linking')
+    })
+
+    it('returns 404 when exercise not found', async () => {
+      mockPrisma.soundChangeExercise.findUnique.mockResolvedValueOnce(null)
+
+      const response = await request(app).get('/api/sound-changes/exercises/non-existent')
+
+      expect(response.status).toBe(404)
+      expect(response.body).toHaveProperty('error', 'Exercise not found')
+    })
+  })
+
+  describe('POST /api/sound-changes/progress', () => {
+    it('records a correct answer', async () => {
+      mockPrisma.soundChangeExerciseItem.findUnique.mockResolvedValueOnce(mockItem)
+
+      const response = await request(app)
+        .post('/api/sound-changes/progress')
+        .send({
+          userId: 1,
+          itemId: 'item-1',
+          accuracy: 100,
+          isCorrect: true,
+        })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('progress')
+      expect(response.body.progress).toHaveProperty('itemId', 'item-1')
+      expect(response.body.progress).toHaveProperty('isCorrect', true)
+      expect(response.body.progress).toHaveProperty('accuracy', 100)
+    })
+
+    it('returns 400 when userId is missing', async () => {
+      const response = await request(app)
+        .post('/api/sound-changes/progress')
+        .send({ itemId: 'item-1', accuracy: 100, isCorrect: true })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 400 when itemId is missing', async () => {
+      const response = await request(app)
+        .post('/api/sound-changes/progress')
+        .send({ userId: 1, accuracy: 100, isCorrect: true })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 400 when accuracy is not a number', async () => {
+      const response = await request(app)
+        .post('/api/sound-changes/progress')
+        .send({ userId: 1, itemId: 'item-1', accuracy: 'high', isCorrect: true })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 400 when isCorrect is not boolean', async () => {
+      const response = await request(app)
+        .post('/api/sound-changes/progress')
+        .send({ userId: 1, itemId: 'item-1', accuracy: 100, isCorrect: 'yes' })
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns 404 when item does not exist', async () => {
+      mockPrisma.soundChangeExerciseItem.findUnique.mockResolvedValueOnce(null)
+
+      const response = await request(app)
+        .post('/api/sound-changes/progress')
+        .send({ userId: 1, itemId: 'non-existent', accuracy: 100, isCorrect: true })
+
+      expect(response.status).toBe(404)
+      expect(response.body).toHaveProperty('error', 'Exercise item not found')
+    })
+  })
+
+  describe('GET /api/sound-changes/progress/summary', () => {
+    it('returns progress summary for a user', async () => {
+      const categories = [
+        {
+          ...mockCategory,
+          exercises: [
+            {
+              ...mockExercise,
+              items: [{ id: 'item-1' }, { id: 'item-2' }],
+            },
+          ],
+        },
+      ]
+      mockPrisma.soundChangeCategory.findMany.mockResolvedValueOnce(categories)
+      mockPrisma.soundChangeProgress.findMany.mockResolvedValueOnce([
+        { ...mockProgress, itemId: 'item-1', accuracy: 100, isCorrect: true },
+        { ...mockProgress, id: 'p2', itemId: 'item-2', accuracy: 60, isCorrect: false },
+      ])
+
+      const response = await request(app)
+        .get('/api/sound-changes/progress/summary?userId=1')
+
+      expect(response.status).toBe(200)
+      expect(response.body.totalCategories).toBe(1)
+      expect(response.body.totalItems).toBe(2)
+      expect(response.body.answeredItems).toBe(2)
+      expect(response.body.averageAccuracy).toBe(80)
+    })
+
+    it('returns 400 when userId is missing', async () => {
+      const response = await request(app)
+        .get('/api/sound-changes/progress/summary')
+
+      expect(response.status).toBe(400)
+      expect(response.body).toHaveProperty('error')
+    })
+
+    it('returns zero values when no progress exists', async () => {
+      mockPrisma.soundChangeCategory.findMany.mockResolvedValueOnce([])
+      mockPrisma.soundChangeProgress.findMany.mockResolvedValueOnce([])
+
+      const response = await request(app)
+        .get('/api/sound-changes/progress/summary?userId=1')
+
+      expect(response.status).toBe(200)
+      expect(response.body.totalCategories).toBe(0)
+      expect(response.body.totalItems).toBe(0)
+      expect(response.body.answeredItems).toBe(0)
+      expect(response.body.averageAccuracy).toBe(0)
+    })
+  })
+})

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,7 @@ import lessonsRouter from './routes/lessons';
 import qaItemsRouter from './routes/qa-items';
 import callanProgressRouter from './routes/callan-progress';
 import listeningPracticeRouter from './routes/listening-practice';
+import soundChangesRouter from './routes/sound-changes';
 
 export function createApp(prisma?: unknown) {
   const app = express();
@@ -50,6 +51,7 @@ export function createApp(prisma?: unknown) {
   app.use('/api/qa-items', qaItemsRouter);
   app.use('/api/callan/progress', callanProgressRouter);
   app.use('/api/listening', listeningPracticeRouter);
+  app.use('/api/sound-changes', soundChangesRouter);
 
   // Error handling
   app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/backend/src/data/sound-changes.json
+++ b/backend/src/data/sound-changes.json
@@ -1,0 +1,404 @@
+{
+  "categories": [
+    {
+      "name": "Linking",
+      "nameJa": "連結",
+      "slug": "linking",
+      "description": "When a word ending in a consonant is followed by a word beginning with a vowel, they connect smoothly. Example: 'pick up' sounds like 'pi-kup'.",
+      "exercises": [
+        {
+          "title": "Basic Linking Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/linking/01-001.mp3",
+              "sentence": "Can I pick it up?",
+              "blank": "pick it up",
+              "blankIndex": 2,
+              "explanation": "'pick it up' links together as 'pi-ki-tup'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/linking/01-002.mp3",
+              "sentence": "Turn it off right away.",
+              "blank": "Turn it off",
+              "blankIndex": 0,
+              "explanation": "'Turn it off' links as 'tur-ni-toff'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/linking/01-003.mp3",
+              "sentence": "I need an apple.",
+              "blank": "an apple",
+              "blankIndex": 2,
+              "explanation": "'an apple' links as 'a-napple'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/linking/01-004.mp3",
+              "sentence": "Look at it again.",
+              "explanation": "'Look at it again' links as 'loo-ka-ti-tagain'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/linking/01-005.mp3",
+              "sentence": "Put it on the table.",
+              "explanation": "'Put it on' links as 'pu-ti-ton'"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Elision",
+      "nameJa": "脱落",
+      "slug": "elision",
+      "description": "Certain sounds are dropped in natural speech, especially /t/ and /d/ between consonants. Example: 'next day' sounds like 'neks day'.",
+      "exercises": [
+        {
+          "title": "Basic Elision Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/elision/01-001.mp3",
+              "sentence": "See you next week.",
+              "blank": "next week",
+              "blankIndex": 2,
+              "explanation": "The /t/ in 'next' is dropped before the /w/ in 'week'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/elision/01-002.mp3",
+              "sentence": "He left the building.",
+              "blank": "left the",
+              "blankIndex": 1,
+              "explanation": "The /t/ in 'left' is often dropped before 'the'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/elision/01-003.mp3",
+              "sentence": "I must go now.",
+              "blank": "must go",
+              "blankIndex": 1,
+              "explanation": "The /t/ in 'must' is dropped before the /g/ in 'go'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/elision/01-004.mp3",
+              "sentence": "The last time we met.",
+              "explanation": "The /t/ in 'last' is dropped before 'time'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/elision/01-005.mp3",
+              "sentence": "Send me the documents.",
+              "explanation": "The /d/ in 'send' is dropped before 'me'"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Assimilation",
+      "nameJa": "同化",
+      "slug": "assimilation",
+      "description": "Adjacent sounds influence each other and change. Example: 'would you' sounds like 'wʊdʒuː' where /d/+/j/ becomes /dʒ/.",
+      "exercises": [
+        {
+          "title": "Basic Assimilation Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/assimilation/01-001.mp3",
+              "sentence": "Would you like some tea?",
+              "blank": "Would you",
+              "blankIndex": 0,
+              "explanation": "'Would you' assimilates to sound like 'wʊdʒu' (/d/+/j/ → /dʒ/)"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/assimilation/01-002.mp3",
+              "sentence": "Did you see that?",
+              "blank": "Did you",
+              "blankIndex": 0,
+              "explanation": "'Did you' assimilates to 'didʒu' (/d/+/j/ → /dʒ/)"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/assimilation/01-003.mp3",
+              "sentence": "I miss you so much.",
+              "blank": "miss you",
+              "blankIndex": 1,
+              "explanation": "'miss you' assimilates to 'miʃu' (/s/+/j/ → /ʃ/)"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/assimilation/01-004.mp3",
+              "sentence": "What do you think?",
+              "explanation": "'What do you' assimilates: 'wɒdʒə' (/t/+/d/ → /d/, /d/+/j/ → /dʒ/)"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/assimilation/01-005.mp3",
+              "sentence": "Could you help me with this?",
+              "explanation": "'Could you' assimilates to 'kʊdʒu' (/d/+/j/ → /dʒ/)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Reduction",
+      "nameJa": "弱化",
+      "slug": "reduction",
+      "description": "Function words (articles, prepositions, auxiliaries) are pronounced weakly and shortened. Example: 'can' becomes /kən/, 'to' becomes /tə/.",
+      "exercises": [
+        {
+          "title": "Basic Reduction Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/reduction/01-001.mp3",
+              "sentence": "I can do it.",
+              "blank": "can",
+              "blankIndex": 1,
+              "explanation": "'can' is reduced to /kən/ in natural speech"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/reduction/01-002.mp3",
+              "sentence": "I want to go home.",
+              "blank": "want to",
+              "blankIndex": 1,
+              "explanation": "'want to' reduces to 'wanna' /wɒnə/ in casual speech"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/reduction/01-003.mp3",
+              "sentence": "Give it to him.",
+              "blank": "to him",
+              "blankIndex": 2,
+              "explanation": "'to' reduces to /tə/ and 'him' reduces to /ɪm/"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/reduction/01-004.mp3",
+              "sentence": "She was at the store.",
+              "explanation": "'was' reduces to /wəz/, 'at' to /ət/, 'the' to /ðə/"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/reduction/01-005.mp3",
+              "sentence": "He has been working for hours.",
+              "explanation": "'has' reduces to /əz/, 'been' to /bɪn/, 'for' to /fər/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Flapping",
+      "nameJa": "フラッピング",
+      "slug": "flapping",
+      "description": "In American English, /t/ and /d/ between vowels become a quick tap sound (like Japanese ラ). Example: 'water' sounds like 'wader'.",
+      "exercises": [
+        {
+          "title": "Basic Flapping Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/flapping/01-001.mp3",
+              "sentence": "Can I have some water?",
+              "blank": "water",
+              "blankIndex": 4,
+              "explanation": "The /t/ in 'water' becomes a flap [ɾ], sounding like 'wader'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/flapping/01-002.mp3",
+              "sentence": "That is a lot better.",
+              "blank": "better",
+              "blankIndex": 4,
+              "explanation": "The /tt/ in 'better' becomes a flap, sounding like 'bedder'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/flapping/01-003.mp3",
+              "sentence": "I need a little more time.",
+              "blank": "little",
+              "blankIndex": 3,
+              "explanation": "The /tt/ in 'little' becomes a flap, sounding like 'liddle'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/flapping/01-004.mp3",
+              "sentence": "The city is really beautiful.",
+              "explanation": "The /t/ in 'city' and 'beautiful' both become flaps"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/flapping/01-005.mp3",
+              "sentence": "I got a letter from my daughter.",
+              "explanation": "The /t/ in 'got a', 'letter', and 'daughter' all become flaps"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Contraction",
+      "nameJa": "短縮",
+      "slug": "contraction",
+      "description": "Words are combined and shortened in natural speech. Example: 'I will' becomes 'I'll', 'do not' becomes 'don't'.",
+      "exercises": [
+        {
+          "title": "Basic Contraction Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/contraction/01-001.mp3",
+              "sentence": "I'll be there soon.",
+              "blank": "I'll",
+              "blankIndex": 0,
+              "explanation": "'I will' contracts to 'I'll' /aɪl/"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/contraction/01-002.mp3",
+              "sentence": "She's been working all day.",
+              "blank": "She's",
+              "blankIndex": 0,
+              "explanation": "'She has' contracts to 'She's' /ʃiːz/"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/contraction/01-003.mp3",
+              "sentence": "They wouldn't have known.",
+              "blank": "wouldn't have",
+              "blankIndex": 1,
+              "explanation": "'would not have' contracts to 'wouldn't have' or even 'wouldn't've'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/contraction/01-004.mp3",
+              "sentence": "We've got to leave now.",
+              "explanation": "'We have' contracts to 'We've', 'got to' often sounds like 'gotta'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/contraction/01-005.mp3",
+              "sentence": "I don't think he's coming.",
+              "explanation": "'do not' → 'don't', 'he is' → 'he's'"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Dark L",
+      "nameJa": "暗いL",
+      "slug": "dark-l",
+      "description": "The /l/ sound at the end of a syllable or before a consonant becomes 'dark' (velarized). Example: 'all' has a dark L that sounds almost like a vowel.",
+      "exercises": [
+        {
+          "title": "Basic Dark L Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/dark-l/01-001.mp3",
+              "sentence": "I like milk a lot.",
+              "blank": "milk",
+              "blankIndex": 2,
+              "explanation": "The /l/ in 'milk' is dark, sounding almost like 'miok'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/dark-l/01-002.mp3",
+              "sentence": "She is a helpful person.",
+              "blank": "helpful",
+              "blankIndex": 3,
+              "explanation": "The /l/ at the end of 'helpful' is dark and vowel-like"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/dark-l/01-003.mp3",
+              "sentence": "The ball rolled down the hill.",
+              "blank": "ball",
+              "blankIndex": 1,
+              "explanation": "The /l/ in 'ball' and 'hill' are both dark L sounds"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/dark-l/01-004.mp3",
+              "sentence": "All the people were helpful.",
+              "explanation": "'All', 'people', and 'helpful' all contain dark L sounds"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/dark-l/01-005.mp3",
+              "sentence": "I feel like I should call them.",
+              "explanation": "'feel', 'call' contain dark L at syllable end"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Glottalization",
+      "nameJa": "声門閉鎖音化",
+      "slug": "glottalization",
+      "description": "The /t/ sound is replaced by a glottal stop (a catch in the throat). Example: 'button' sounds like 'bu-ʔn' where the /t/ becomes a glottal stop.",
+      "exercises": [
+        {
+          "title": "Basic Glottalization Practice",
+          "difficulty": "beginner",
+          "items": [
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/glottalization/01-001.mp3",
+              "sentence": "Press the button to start.",
+              "blank": "button",
+              "blankIndex": 2,
+              "explanation": "The /t/ in 'button' becomes a glottal stop: 'bu-ʔn'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/glottalization/01-002.mp3",
+              "sentence": "The kitten is very cute.",
+              "blank": "kitten",
+              "blankIndex": 1,
+              "explanation": "The /t/ in 'kitten' becomes a glottal stop: 'ki-ʔn'"
+            },
+            {
+              "type": "fill_blank",
+              "audioPath": "/audio/sound-changes/glottalization/01-003.mp3",
+              "sentence": "We went to the mountain.",
+              "blank": "mountain",
+              "blankIndex": 4,
+              "explanation": "The /t/ in 'mountain' becomes a glottal stop: 'moun-ʔn'"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/glottalization/01-004.mp3",
+              "sentence": "The cotton shirt has a button missing.",
+              "explanation": "'cotton' and 'button' both have glottal stops replacing /t/"
+            },
+            {
+              "type": "dictation",
+              "audioPath": "/audio/sound-changes/glottalization/01-005.mp3",
+              "sentence": "I bought a carton of milk at the market.",
+              "explanation": "'carton' and 'market' can have glottal stops for /t/"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/src/prisma/migrations/20260205124819_add_sound_change_models/migration.sql
+++ b/backend/src/prisma/migrations/20260205124819_add_sound_change_models/migration.sql
@@ -1,0 +1,73 @@
+-- CreateTable
+CREATE TABLE "SoundChangeCategory" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "nameJa" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "order" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SoundChangeCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SoundChangeExercise" (
+    "id" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "difficulty" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SoundChangeExercise_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SoundChangeExerciseItem" (
+    "id" TEXT NOT NULL,
+    "exerciseId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "audioPath" TEXT NOT NULL,
+    "sentence" TEXT NOT NULL,
+    "blank" TEXT,
+    "blankIndex" INTEGER,
+    "explanation" TEXT,
+    "order" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SoundChangeExerciseItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SoundChangeProgress" (
+    "id" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "itemId" TEXT NOT NULL,
+    "accuracy" INTEGER NOT NULL,
+    "isCorrect" BOOLEAN NOT NULL,
+    "answeredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SoundChangeProgress_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SoundChangeCategory_slug_key" ON "SoundChangeCategory"("slug");
+
+-- CreateIndex
+CREATE INDEX "SoundChangeProgress_userId_itemId_idx" ON "SoundChangeProgress"("userId", "itemId");
+
+-- AddForeignKey
+ALTER TABLE "SoundChangeExercise" ADD CONSTRAINT "SoundChangeExercise_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "SoundChangeCategory"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SoundChangeExerciseItem" ADD CONSTRAINT "SoundChangeExerciseItem_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "SoundChangeExercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SoundChangeProgress" ADD CONSTRAINT "SoundChangeProgress_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SoundChangeProgress" ADD CONSTRAINT "SoundChangeProgress_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "SoundChangeExerciseItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   lessons             Lesson[]
   callanProgress      CallanProgress[]
   listeningProgress   ListeningProgress[]
+  soundChangeProgress SoundChangeProgress[]
   createdAt           DateTime            @default(now())
   updatedAt           DateTime            @updatedAt
 }
@@ -121,4 +122,57 @@ model ListeningProgress {
   answeredAt DateTime          @default(now())
 
   @@index([userId, questionId])
+}
+
+model SoundChangeCategory {
+  id          String                @id @default(uuid())
+  name        String                // "Linking"
+  nameJa      String                // "連結"
+  slug        String                @unique
+  description String?
+  order       Int
+  exercises   SoundChangeExercise[]
+  createdAt   DateTime              @default(now())
+  updatedAt   DateTime              @updatedAt
+}
+
+model SoundChangeExercise {
+  id          String                    @id @default(uuid())
+  categoryId  String
+  category    SoundChangeCategory       @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  title       String
+  difficulty  String                    // beginner, intermediate, advanced
+  order       Int
+  items       SoundChangeExerciseItem[]
+  createdAt   DateTime                  @default(now())
+  updatedAt   DateTime                  @updatedAt
+}
+
+model SoundChangeExerciseItem {
+  id          String                @id @default(uuid())
+  exerciseId  String
+  exercise    SoundChangeExercise   @relation(fields: [exerciseId], references: [id], onDelete: Cascade)
+  type        String                // fill_blank, dictation
+  audioPath   String
+  sentence    String
+  blank       String?               // 穴埋めの正解語句（fill_blankのみ）
+  blankIndex  Int?                  // 穴埋め位置（0-based word index）
+  explanation String?
+  order       Int
+  progresses  SoundChangeProgress[]
+  createdAt   DateTime              @default(now())
+  updatedAt   DateTime              @updatedAt
+}
+
+model SoundChangeProgress {
+  id         String                  @id @default(uuid())
+  userId     Int
+  user       User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  itemId     String
+  item       SoundChangeExerciseItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  accuracy   Int                     // 0-100
+  isCorrect  Boolean
+  answeredAt DateTime                @default(now())
+
+  @@index([userId, itemId])
 }

--- a/backend/src/routes/sound-changes.ts
+++ b/backend/src/routes/sound-changes.ts
@@ -5,8 +5,6 @@ const router = Router();
 
 type PrismaLike = Pick<PrismaClient, 'soundChangeCategory' | 'soundChangeExercise' | 'soundChangeExerciseItem' | 'soundChangeProgress'>;
 
-const VALID_DIFFICULTIES = ['beginner', 'intermediate', 'advanced'] as const;
-
 // GET /api/sound-changes/categories - List all categories
 router.get('/categories', async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/backend/src/routes/sound-changes.ts
+++ b/backend/src/routes/sound-changes.ts
@@ -1,0 +1,214 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const router = Router();
+
+type PrismaLike = Pick<PrismaClient, 'soundChangeCategory' | 'soundChangeExercise' | 'soundChangeExerciseItem' | 'soundChangeProgress'>;
+
+const VALID_DIFFICULTIES = ['beginner', 'intermediate', 'advanced'] as const;
+
+// GET /api/sound-changes/categories - List all categories
+router.get('/categories', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const prisma = req.app.locals.prisma as PrismaLike;
+
+    const categories = await prisma.soundChangeCategory.findMany({
+      orderBy: { order: 'asc' },
+      include: {
+        exercises: {
+          select: { id: true },
+        },
+      },
+    });
+
+    res.json({ categories });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/sound-changes/categories/:slug - Get category with exercises
+router.get('/categories/:slug', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const prisma = req.app.locals.prisma as PrismaLike;
+    const { slug } = req.params;
+
+    const category = await prisma.soundChangeCategory.findFirst({
+      where: { slug },
+      include: {
+        exercises: {
+          orderBy: { order: 'asc' },
+          include: {
+            items: {
+              select: { id: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!category) {
+      return res.status(404).json({ error: 'Category not found' });
+    }
+
+    res.json({ category });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/sound-changes/exercises/:id - Get exercise with items
+router.get('/exercises/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const prisma = req.app.locals.prisma as PrismaLike;
+    const { id } = req.params;
+
+    const exercise = await prisma.soundChangeExercise.findUnique({
+      where: { id },
+      include: {
+        category: {
+          select: { name: true, nameJa: true, slug: true },
+        },
+        items: {
+          orderBy: { order: 'asc' },
+        },
+      },
+    });
+
+    if (!exercise) {
+      return res.status(404).json({ error: 'Exercise not found' });
+    }
+
+    res.json({ exercise });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/sound-changes/progress - Record answer result
+router.post('/progress', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const prisma = req.app.locals.prisma as PrismaLike;
+    const { userId, itemId, accuracy, isCorrect } = req.body;
+
+    if (typeof userId !== 'number' || !Number.isInteger(userId)) {
+      return res.status(400).json({ error: 'userId must be an integer' });
+    }
+
+    if (typeof itemId !== 'string' || !itemId.trim()) {
+      return res.status(400).json({ error: 'itemId is required' });
+    }
+
+    if (typeof accuracy !== 'number' || accuracy < 0 || accuracy > 100) {
+      return res.status(400).json({ error: 'accuracy must be a number between 0 and 100' });
+    }
+
+    if (typeof isCorrect !== 'boolean') {
+      return res.status(400).json({ error: 'isCorrect must be a boolean' });
+    }
+
+    const item = await prisma.soundChangeExerciseItem.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!item) {
+      return res.status(404).json({ error: 'Exercise item not found' });
+    }
+
+    const progress = await prisma.soundChangeProgress.create({
+      data: {
+        userId,
+        itemId,
+        accuracy,
+        isCorrect,
+      },
+    });
+
+    res.json({ progress });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/sound-changes/progress/summary - Get progress summary
+router.get('/progress/summary', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const prisma = req.app.locals.prisma as PrismaLike;
+    const userId = parseInt(req.query.userId as string, 10);
+
+    if (isNaN(userId)) {
+      return res.status(400).json({ error: 'userId query parameter is required' });
+    }
+
+    const categories = await prisma.soundChangeCategory.findMany({
+      include: {
+        exercises: {
+          include: {
+            items: { select: { id: true } },
+          },
+        },
+      },
+    });
+
+    const allProgress = await prisma.soundChangeProgress.findMany({
+      where: { userId },
+    });
+
+    const totalCategories = categories.length;
+    const totalItems = categories.reduce(
+      (sum, cat) => sum + cat.exercises.reduce(
+        (eSum, ex) => eSum + ex.items.length, 0
+      ), 0
+    );
+
+    const answeredItemIds = new Set(allProgress.map(p => p.itemId));
+    const answeredItems = answeredItemIds.size;
+
+    // Calculate average accuracy from the latest attempt per item
+    const latestByItem = new Map<string, { accuracy: number; isCorrect: boolean }>();
+    for (const p of allProgress) {
+      latestByItem.set(p.itemId, { accuracy: p.accuracy, isCorrect: p.isCorrect });
+    }
+    const accuracyValues = Array.from(latestByItem.values()).map(v => v.accuracy);
+    const averageAccuracy = accuracyValues.length > 0
+      ? Math.round(accuracyValues.reduce((sum, a) => sum + a, 0) / accuracyValues.length)
+      : 0;
+
+    const correctItems = Array.from(latestByItem.values()).filter(v => v.isCorrect).length;
+
+    // Per-category stats
+    const byCategory = categories.map(cat => {
+      const catItemIds = new Set(
+        cat.exercises.flatMap(ex => ex.items.map(item => item.id))
+      );
+      const catProgress = allProgress.filter(p => catItemIds.has(p.itemId));
+      const catAnswered = new Set(catProgress.map(p => p.itemId)).size;
+      const catAccuracyValues = catProgress.map(p => p.accuracy);
+      const catAvgAccuracy = catAccuracyValues.length > 0
+        ? Math.round(catAccuracyValues.reduce((s, a) => s + a, 0) / catAccuracyValues.length)
+        : 0;
+
+      return {
+        categoryId: cat.id,
+        name: cat.name,
+        totalExercises: cat.exercises.length,
+        totalItems: cat.exercises.reduce((s, ex) => s + ex.items.length, 0),
+        answeredItems: catAnswered,
+        averageAccuracy: catAvgAccuracy,
+      };
+    });
+
+    res.json({
+      totalCategories,
+      totalItems,
+      answeredItems,
+      correctItems,
+      averageAccuracy,
+      byCategory,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/seed-sound-changes.ts
+++ b/backend/src/seed-sound-changes.ts
@@ -1,0 +1,172 @@
+import { PrismaClient } from '@prisma/client';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const prisma = new PrismaClient();
+
+interface ItemData {
+  type: string;
+  audioPath: string;
+  sentence: string;
+  blank?: string;
+  blankIndex?: number;
+  explanation?: string;
+}
+
+interface ExerciseData {
+  title: string;
+  difficulty: string;
+  items: ItemData[];
+}
+
+interface CategoryData {
+  name: string;
+  nameJa: string;
+  slug: string;
+  description: string;
+  exercises: ExerciseData[];
+}
+
+interface SoundChangeData {
+  categories: CategoryData[];
+}
+
+const validDifficulties = ['beginner', 'intermediate', 'advanced'];
+const validTypes = ['fill_blank', 'dictation'];
+
+function validateData(data: unknown): SoundChangeData {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Data file must contain a JSON object');
+  }
+
+  const obj = data as Record<string, unknown>;
+  if (!Array.isArray(obj.categories)) {
+    throw new Error('Data file must contain a "categories" array');
+  }
+
+  if (obj.categories.length === 0) {
+    throw new Error('Data file contains no categories - nothing to seed');
+  }
+
+  for (let i = 0; i < obj.categories.length; i++) {
+    const category = obj.categories[i] as Record<string, unknown>;
+    if (!category.name || !category.nameJa || !category.slug) {
+      throw new Error(`Category ${i + 1} is missing required properties (name, nameJa, slug)`);
+    }
+    if (!Array.isArray(category.exercises) || category.exercises.length === 0) {
+      throw new Error(`Category "${category.name}" must have at least one exercise`);
+    }
+
+    for (let j = 0; j < (category.exercises as ExerciseData[]).length; j++) {
+      const exercise = (category.exercises as ExerciseData[])[j];
+      if (!exercise.title || !exercise.difficulty) {
+        throw new Error(`Exercise ${j + 1} in "${category.name}" is missing required properties`);
+      }
+      if (!validDifficulties.includes(exercise.difficulty)) {
+        throw new Error(`Exercise "${exercise.title}" has invalid difficulty "${exercise.difficulty}"`);
+      }
+      if (!Array.isArray(exercise.items) || exercise.items.length === 0) {
+        throw new Error(`Exercise "${exercise.title}" must have at least one item`);
+      }
+
+      for (let k = 0; k < exercise.items.length; k++) {
+        const item = exercise.items[k];
+        if (!validTypes.includes(item.type)) {
+          throw new Error(`Item ${k + 1} in "${exercise.title}" has invalid type "${item.type}"`);
+        }
+        if (!item.audioPath || !item.sentence) {
+          throw new Error(`Item ${k + 1} in "${exercise.title}" is missing audioPath or sentence`);
+        }
+        if (item.type === 'fill_blank' && (!item.blank || item.blankIndex === undefined)) {
+          throw new Error(`Fill-blank item ${k + 1} in "${exercise.title}" is missing blank or blankIndex`);
+        }
+      }
+    }
+  }
+
+  return obj as unknown as SoundChangeData;
+}
+
+async function main() {
+  console.log('Starting sound changes seed...');
+
+  const dataPath = path.join(__dirname, 'data/sound-changes.json');
+  if (!fs.existsSync(dataPath)) {
+    throw new Error(`Data file not found: ${dataPath}`);
+  }
+
+  const rawData = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+  const data = validateData(rawData);
+
+  await prisma.$transaction(async (tx) => {
+    // Delete existing data in dependency order
+    await tx.soundChangeProgress.deleteMany();
+    await tx.soundChangeExerciseItem.deleteMany();
+    await tx.soundChangeExercise.deleteMany();
+    await tx.soundChangeCategory.deleteMany();
+
+    let totalCategories = 0;
+    let totalExercises = 0;
+    let totalItems = 0;
+
+    for (let i = 0; i < data.categories.length; i++) {
+      const catData = data.categories[i];
+
+      const category = await tx.soundChangeCategory.create({
+        data: {
+          name: catData.name,
+          nameJa: catData.nameJa,
+          slug: catData.slug,
+          description: catData.description || null,
+          order: i + 1,
+        },
+      });
+
+      for (let j = 0; j < catData.exercises.length; j++) {
+        const exData = catData.exercises[j];
+
+        const exercise = await tx.soundChangeExercise.create({
+          data: {
+            categoryId: category.id,
+            title: exData.title,
+            difficulty: exData.difficulty,
+            order: j + 1,
+          },
+        });
+
+        await tx.soundChangeExerciseItem.createMany({
+          data: exData.items.map((item, k) => ({
+            exerciseId: exercise.id,
+            type: item.type,
+            audioPath: item.audioPath,
+            sentence: item.sentence,
+            blank: item.blank || null,
+            blankIndex: item.blankIndex ?? null,
+            explanation: item.explanation || null,
+            order: k + 1,
+          })),
+        });
+
+        totalItems += exData.items.length;
+        totalExercises++;
+        console.log(`  Created exercise: ${exData.title} (${catData.name}, ${exData.difficulty}) with ${exData.items.length} items`);
+      }
+
+      totalCategories++;
+    }
+
+    console.log(`\nSeed completed successfully!`);
+    console.log(`Total categories: ${totalCategories}`);
+    console.log(`Total exercises: ${totalExercises}`);
+    console.log(`Total items: ${totalItems}`);
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error('Seed failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,9 @@ import CallanShadowingPage from "./pages/CallanShadowingPage";
 import CallanDictationPage from "./pages/CallanDictationPage";
 import ListeningPractice from "./pages/ListeningPractice";
 import ListeningPracticeSession from "./pages/ListeningPracticeSession";
+import SoundChangeHome from "./pages/SoundChangeHome";
+import SoundChangeCategoryDetail from "./pages/SoundChangeCategoryDetail";
+import SoundChangePracticeSession from "./pages/SoundChangePracticeSession";
 
 function App() {
   return (
@@ -57,6 +60,15 @@ function App() {
               <Route
                 path="/listening-practice/:passageId"
                 element={<ListeningPracticeSession />}
+              />
+              <Route path="/sound-changes" element={<SoundChangeHome />} />
+              <Route
+                path="/sound-changes/:slug"
+                element={<SoundChangeCategoryDetail />}
+              />
+              <Route
+                path="/sound-changes/practice/:exerciseId"
+                element={<SoundChangePracticeSession />}
               />
             </Routes>
           </main>

--- a/frontend/src/components/SoundChangeDictation.tsx
+++ b/frontend/src/components/SoundChangeDictation.tsx
@@ -1,0 +1,225 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { compareDictation, type DictationResult } from "../utils/dictationDiff";
+import { Button, Card } from "./ui";
+import type { SoundChangeExerciseItem } from "../types";
+
+interface SoundChangeDictationProps {
+  item: SoundChangeExerciseItem;
+  onPlay: () => void;
+  isPlaying: boolean;
+  onResult: (isCorrect: boolean, accuracy: number) => void;
+  onNext: () => void;
+  isLast: boolean;
+}
+
+type State = "input" | "checked";
+
+export function SoundChangeDictation({
+  item,
+  onPlay,
+  isPlaying,
+  onResult,
+  onNext,
+  isLast,
+}: SoundChangeDictationProps) {
+  const [state, setState] = useState<State>("input");
+  const [userInput, setUserInput] = useState("");
+  const [result, setResult] = useState<DictationResult | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Focus input on mount and item change
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [item.id]);
+
+  // Reset state when item changes
+  useEffect(() => {
+    setState("input");
+    setUserInput("");
+    setResult(null);
+  }, [item.id]);
+
+  const handleCheck = useCallback(() => {
+    if (!userInput.trim() || state === "checked") return;
+
+    const dictationResult = compareDictation(userInput, item.sentence);
+    setResult(dictationResult);
+    setState("checked");
+    onResult(dictationResult.isCorrect, dictationResult.accuracy);
+  }, [userInput, state, item.sentence, onResult]);
+
+  const handleNext = useCallback(() => {
+    onNext();
+  }, [onNext]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLTextAreaElement) {
+        if (e.key === "Enter" && !e.shiftKey && state === "input") {
+          e.preventDefault();
+          handleCheck();
+        }
+        return;
+      }
+
+      switch (e.key.toLowerCase()) {
+        case "p":
+          onPlay();
+          break;
+        case "enter":
+          if (state === "input") {
+            handleCheck();
+          } else if (state === "checked") {
+            handleNext();
+          }
+          break;
+        case "n":
+          if (state === "checked") {
+            handleNext();
+          }
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [state, onPlay, handleCheck, handleNext]);
+
+  return (
+    <Card className="p-6">
+      <div className="mb-4">
+        <p className="text-xs text-text-muted uppercase tracking-wide mb-3">
+          Listen and type what you hear
+        </p>
+
+        {/* Play button */}
+        <Button variant="primary" onClick={onPlay} disabled={isPlaying}>
+          {isPlaying ? "Playing..." : "Play (P)"}
+        </Button>
+      </div>
+
+      {/* Text input */}
+      <div className="mb-4">
+        <textarea
+          ref={inputRef}
+          value={userInput}
+          onChange={(e) => setUserInput(e.target.value)}
+          placeholder="Type what you hear..."
+          disabled={state === "checked"}
+          className="w-full p-4 border border-border rounded-lg bg-surface text-text-primary placeholder:text-text-muted resize-none min-h-[100px] focus:outline-none focus:ring-2 focus:ring-primary/50 disabled:opacity-50"
+          rows={3}
+        />
+      </div>
+
+      {/* Check button */}
+      {state === "input" && (
+        <Button
+          variant="primary"
+          onClick={handleCheck}
+          disabled={!userInput.trim()}
+          className="w-full"
+        >
+          Check Answer (Enter)
+        </Button>
+      )}
+
+      {/* Result */}
+      {state === "checked" && result && (
+        <div className="space-y-4">
+          {/* Accuracy */}
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-text-primary">Result</h3>
+            <span
+              className={`text-2xl font-bold ${
+                result.accuracy === 100
+                  ? "text-success"
+                  : result.accuracy >= 80
+                    ? "text-warning"
+                    : "text-error"
+              }`}
+            >
+              {result.accuracy}%
+            </span>
+          </div>
+
+          {/* Diff display */}
+          <div className="p-4 bg-surface-elevated rounded-lg">
+            <p className="text-xs text-text-muted uppercase tracking-wide mb-2">
+              Your answer
+            </p>
+            <div className="text-lg leading-relaxed flex flex-wrap gap-1">
+              {result.diff.map((segment, idx) => (
+                <span
+                  key={idx}
+                  className={
+                    segment.type === "correct"
+                      ? "text-success"
+                      : segment.type === "wrong"
+                        ? "text-error line-through"
+                        : segment.type === "missing"
+                          ? "text-warning bg-warning/10 px-1 rounded"
+                          : "text-error/50 bg-error/10 px-1 rounded line-through"
+                  }
+                  title={
+                    segment.type === "wrong"
+                      ? `Expected: ${segment.expected}`
+                      : segment.type === "missing"
+                        ? "Missing word"
+                        : segment.type === "extra"
+                          ? "Extra word"
+                          : undefined
+                  }
+                >
+                  {segment.text}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Correct answer */}
+          <div className="p-4 bg-success/10 rounded-lg border border-success/20">
+            <p className="text-xs text-text-muted uppercase tracking-wide mb-2">
+              Correct answer
+            </p>
+            <p className="text-lg font-medium text-text-primary">
+              {item.sentence}
+            </p>
+          </div>
+
+          {/* Explanation */}
+          {item.explanation && (
+            <div className="p-4 bg-primary/5 rounded-lg border border-primary/10">
+              <p className="text-xs text-text-muted uppercase tracking-wide mb-1">
+                Sound Change
+              </p>
+              <p className="text-sm text-text-secondary">{item.explanation}</p>
+            </div>
+          )}
+
+          {/* Legend */}
+          <div className="flex flex-wrap gap-4 text-sm">
+            <span className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded bg-success"></span>
+              <span className="text-text-secondary">Correct</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded bg-error"></span>
+              <span className="text-text-secondary">Wrong</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded bg-warning"></span>
+              <span className="text-text-secondary">Missing</span>
+            </span>
+          </div>
+
+          <Button variant="primary" onClick={handleNext} className="w-full">
+            {isLast ? "Finish" : "Next (N)"}
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default SoundChangeDictation;

--- a/frontend/src/components/SoundChangeFillBlank.tsx
+++ b/frontend/src/components/SoundChangeFillBlank.tsx
@@ -1,0 +1,208 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { Button, Card } from "./ui";
+import type { SoundChangeExerciseItem } from "../types";
+
+interface SoundChangeFillBlankProps {
+  item: SoundChangeExerciseItem;
+  onPlay: () => void;
+  isPlaying: boolean;
+  onResult: (isCorrect: boolean, accuracy: number) => void;
+  onNext: () => void;
+  isLast: boolean;
+}
+
+type State = "input" | "checked";
+
+export function SoundChangeFillBlank({
+  item,
+  onPlay,
+  isPlaying,
+  onResult,
+  onNext,
+  isLast,
+}: SoundChangeFillBlankProps) {
+  const [state, setState] = useState<State>("input");
+  const [userAnswer, setUserAnswer] = useState("");
+  const [isCorrect, setIsCorrect] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input on mount and item change
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, [item.id]);
+
+  // Reset state when item changes
+  useEffect(() => {
+    setState("input");
+    setUserAnswer("");
+    setIsCorrect(false);
+  }, [item.id]);
+
+  const handleCheck = useCallback(() => {
+    if (!userAnswer.trim() || state === "checked") return;
+
+    const normalizedAnswer = userAnswer.trim().toLowerCase();
+    const normalizedBlank = (item.blank || "").trim().toLowerCase();
+    const correct = normalizedAnswer === normalizedBlank;
+
+    setIsCorrect(correct);
+    setState("checked");
+    onResult(correct, correct ? 100 : 0);
+  }, [userAnswer, state, item.blank, onResult]);
+
+  const handleNext = useCallback(() => {
+    onNext();
+  }, [onNext]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement) {
+        if (e.key === "Enter" && state === "input") {
+          e.preventDefault();
+          handleCheck();
+        }
+        return;
+      }
+
+      switch (e.key.toLowerCase()) {
+        case "p":
+          onPlay();
+          break;
+        case "enter":
+          if (state === "input") {
+            handleCheck();
+          } else if (state === "checked") {
+            handleNext();
+          }
+          break;
+        case "n":
+          if (state === "checked") {
+            handleNext();
+          }
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [state, onPlay, handleCheck, handleNext]);
+
+  // Build sentence display with blank
+  const words = item.sentence.split(" ");
+  const blankIndex = item.blankIndex ?? 0;
+  const blankWords = (item.blank || "").split(" ");
+  const blankLength = blankWords.length;
+
+  return (
+    <Card className="p-6">
+      <div className="mb-4">
+        <p className="text-xs text-text-muted uppercase tracking-wide mb-3">
+          Fill in the blank
+        </p>
+
+        {/* Play button */}
+        <Button variant="primary" onClick={onPlay} disabled={isPlaying}>
+          {isPlaying ? "Playing..." : "Play (P)"}
+        </Button>
+      </div>
+
+      {/* Sentence with blank */}
+      <div className="mb-6 p-4 bg-surface-elevated rounded-lg">
+        <div className="text-lg leading-relaxed flex flex-wrap items-center gap-1">
+          {words.map((word, idx) => {
+            if (idx >= blankIndex && idx < blankIndex + blankLength) {
+              // First blank word shows input
+              if (idx === blankIndex) {
+                return state === "checked" ? (
+                  <span
+                    key={idx}
+                    className={`px-2 py-1 rounded font-medium ${
+                      isCorrect
+                        ? "bg-success/20 text-success"
+                        : "bg-error/20 text-error"
+                    }`}
+                  >
+                    {isCorrect ? userAnswer : item.blank}
+                  </span>
+                ) : (
+                  <input
+                    key={idx}
+                    ref={inputRef}
+                    type="text"
+                    value={userAnswer}
+                    onChange={(e) => setUserAnswer(e.target.value)}
+                    placeholder="..."
+                    className="px-2 py-1 border-b-2 border-primary bg-transparent text-text-primary font-medium focus:outline-none min-w-[100px] max-w-[200px]"
+                  />
+                );
+              }
+              // Other blank words are hidden
+              return null;
+            }
+            return (
+              <span key={idx} className="text-text-primary">
+                {word}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Check button */}
+      {state === "input" && (
+        <Button
+          variant="primary"
+          onClick={handleCheck}
+          disabled={!userAnswer.trim()}
+          className="w-full"
+        >
+          Check Answer (Enter)
+        </Button>
+      )}
+
+      {/* Result */}
+      {state === "checked" && (
+        <div className="space-y-4">
+          <div
+            className={`p-4 rounded-lg border ${
+              isCorrect
+                ? "bg-success/10 border-success/20"
+                : "bg-error/10 border-error/20"
+            }`}
+          >
+            <p
+              className={`font-semibold mb-1 ${isCorrect ? "text-success" : "text-error"}`}
+            >
+              {isCorrect ? "Correct!" : "Incorrect"}
+            </p>
+            {!isCorrect && (
+              <p className="text-text-secondary text-sm">
+                Correct answer:{" "}
+                <span className="font-medium text-text-primary">
+                  {item.blank}
+                </span>
+              </p>
+            )}
+          </div>
+
+          {/* Explanation */}
+          {item.explanation && (
+            <div className="p-4 bg-primary/5 rounded-lg border border-primary/10">
+              <p className="text-xs text-text-muted uppercase tracking-wide mb-1">
+                Sound Change
+              </p>
+              <p className="text-sm text-text-secondary">{item.explanation}</p>
+            </div>
+          )}
+
+          <Button variant="primary" onClick={handleNext} className="w-full">
+            {isLast ? "Finish" : "Next (N)"}
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default SoundChangeFillBlank;

--- a/frontend/src/components/SoundChangePracticePlayer.tsx
+++ b/frontend/src/components/SoundChangePracticePlayer.tsx
@@ -1,0 +1,217 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import { usePrerecordedAudio } from "../hooks/usePrerecordedAudio";
+import { soundChangeApi, DEFAULT_USER_ID } from "../services/api";
+import { SoundChangeFillBlank } from "./SoundChangeFillBlank";
+import { SoundChangeDictation } from "./SoundChangeDictation";
+import type { SoundChangeExerciseItem } from "../types";
+
+export interface PracticeSummary {
+  totalItems: number;
+  correctCount: number;
+  averageAccuracy: number;
+}
+
+interface SoundChangePracticePlayerProps {
+  items: SoundChangeExerciseItem[];
+  onComplete: (summary: PracticeSummary) => void;
+}
+
+export function SoundChangePracticePlayer({
+  items,
+  onComplete,
+}: SoundChangePracticePlayerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [accuracySum, setAccuracySum] = useState(0);
+  const [speed, setSpeed] = useState(1);
+  const [progressSaveError, setProgressSaveError] = useState<string | null>(
+    null,
+  );
+
+  const autoPlayTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { load, play, stop, setPlaybackRate, isPlaying, isLoading, error } =
+    usePrerecordedAudio();
+
+  const currentItem = items[currentIndex];
+  const isLastItem = currentIndex === items.length - 1;
+  const progress = ((currentIndex + 1) / items.length) * 100;
+
+  // Load and auto-play first item
+  useEffect(() => {
+    if (currentItem) {
+      load(currentItem.audioPath);
+    }
+    // Only on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Auto-play after load on mount
+  useEffect(() => {
+    if (!isLoading && currentIndex === 0 && currentItem) {
+      autoPlayTimeoutRef.current = setTimeout(() => {
+        play();
+      }, 300);
+    }
+    return () => {
+      if (autoPlayTimeoutRef.current) {
+        clearTimeout(autoPlayTimeoutRef.current);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (autoPlayTimeoutRef.current) {
+        clearTimeout(autoPlayTimeoutRef.current);
+      }
+      stop();
+    };
+  }, [stop]);
+
+  const handlePlay = useCallback(() => {
+    play();
+  }, [play]);
+
+  const handleResult = useCallback(
+    async (isCorrect: boolean, accuracy: number) => {
+      if (isCorrect) {
+        setCorrectCount((prev) => prev + 1);
+      }
+      setAccuracySum((prev) => prev + accuracy);
+      setProgressSaveError(null);
+
+      try {
+        await soundChangeApi.recordProgress({
+          userId: DEFAULT_USER_ID,
+          itemId: currentItem.id,
+          accuracy: Math.round(accuracy),
+          isCorrect,
+        });
+      } catch (err) {
+        console.error("Failed to record progress:", err);
+        setProgressSaveError(
+          "Progress could not be saved. Your practice will continue.",
+        );
+      }
+    },
+    [currentItem],
+  );
+
+  const handleNext = useCallback(() => {
+    if (isLastItem) {
+      const summary: PracticeSummary = {
+        totalItems: items.length,
+        correctCount,
+        averageAccuracy:
+          items.length > 0 ? Math.round(accuracySum / items.length) : 0,
+      };
+      onComplete(summary);
+    } else {
+      const nextItem = items[currentIndex + 1];
+      setCurrentIndex((prev) => prev + 1);
+      stop();
+      load(nextItem.audioPath);
+      setPlaybackRate(speed);
+      autoPlayTimeoutRef.current = setTimeout(() => {
+        play();
+      }, 300);
+    }
+  }, [
+    isLastItem,
+    items,
+    currentIndex,
+    correctCount,
+    accuracySum,
+    onComplete,
+    stop,
+    load,
+    play,
+    setPlaybackRate,
+    speed,
+  ]);
+
+  const handleSpeedChange = useCallback(
+    (newSpeed: number) => {
+      setSpeed(newSpeed);
+      setPlaybackRate(newSpeed);
+    },
+    [setPlaybackRate],
+  );
+
+  if (!currentItem) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Progress bar */}
+      <div className="flex items-center gap-4">
+        <div className="flex-1 bg-surface-elevated rounded-full h-2">
+          <div
+            className="bg-primary h-2 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <span className="text-text-secondary text-sm whitespace-nowrap">
+          {currentIndex + 1} / {items.length}
+        </span>
+      </div>
+
+      {/* Speed control */}
+      <div className="flex items-center gap-4">
+        <label htmlFor="speed" className="text-text-secondary text-sm">
+          Speed: {speed.toFixed(2)}x
+        </label>
+        <input
+          id="speed"
+          type="range"
+          min="0.5"
+          max="1.5"
+          step="0.25"
+          value={speed}
+          onChange={(e) => handleSpeedChange(parseFloat(e.target.value))}
+          className="flex-1"
+        />
+      </div>
+
+      {/* Exercise item */}
+      {currentItem.type === "fill_blank" ? (
+        <SoundChangeFillBlank
+          item={currentItem}
+          onPlay={handlePlay}
+          isPlaying={isPlaying || isLoading}
+          onResult={handleResult}
+          onNext={handleNext}
+          isLast={isLastItem}
+        />
+      ) : (
+        <SoundChangeDictation
+          item={currentItem}
+          onPlay={handlePlay}
+          isPlaying={isPlaying || isLoading}
+          onResult={handleResult}
+          onNext={handleNext}
+          isLast={isLastItem}
+        />
+      )}
+
+      {/* Error messages */}
+      {error && <p className="text-error text-sm">{error}</p>}
+      {progressSaveError && (
+        <p className="text-warning text-sm">{progressSaveError}</p>
+      )}
+
+      {/* Keyboard shortcuts hint */}
+      <div className="text-center text-text-muted text-xs">
+        <span>Shortcuts: </span>
+        <span className="mx-1">P = Play</span>
+        <span className="mx-1">Enter = Check/Next</span>
+      </div>
+    </div>
+  );
+}
+
+export default SoundChangePracticePlayer;

--- a/frontend/src/hooks/usePrerecordedAudio.ts
+++ b/frontend/src/hooks/usePrerecordedAudio.ts
@@ -1,0 +1,196 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+
+export interface UsePrerecordedAudioReturn {
+  load: (audioPath: string) => void;
+  play: () => void;
+  pause: () => void;
+  stop: () => void;
+  setPlaybackRate: (rate: number) => void;
+  isPlaying: boolean;
+  isLoading: boolean;
+  error: string | null;
+  duration: number;
+  currentTime: number;
+}
+
+export function usePrerecordedAudio(): UsePrerecordedAudioReturn {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const playbackRateRef = useRef(1);
+
+  // Store event handler references for cleanup
+  const handlersRef = useRef<{
+    loadeddata: (() => void) | null;
+    play: (() => void) | null;
+    pause: (() => void) | null;
+    ended: (() => void) | null;
+    timeupdate: (() => void) | null;
+    error: (() => void) | null;
+  }>({
+    loadeddata: null,
+    play: null,
+    pause: null,
+    ended: null,
+    timeupdate: null,
+    error: null,
+  });
+
+  const cleanup = useCallback(() => {
+    if (audioRef.current) {
+      // Remove all event listeners
+      const audio = audioRef.current;
+      const handlers = handlersRef.current;
+
+      if (handlers.loadeddata) {
+        audio.removeEventListener("loadeddata", handlers.loadeddata);
+      }
+      if (handlers.play) {
+        audio.removeEventListener("play", handlers.play);
+      }
+      if (handlers.pause) {
+        audio.removeEventListener("pause", handlers.pause);
+      }
+      if (handlers.ended) {
+        audio.removeEventListener("ended", handlers.ended);
+      }
+      if (handlers.timeupdate) {
+        audio.removeEventListener("timeupdate", handlers.timeupdate);
+      }
+      if (handlers.error) {
+        audio.removeEventListener("error", handlers.error);
+      }
+
+      audio.pause();
+      audio.removeAttribute("src");
+      audio.load();
+      audioRef.current = null;
+
+      // Clear handler references
+      handlersRef.current = {
+        loadeddata: null,
+        play: null,
+        pause: null,
+        ended: null,
+        timeupdate: null,
+        error: null,
+      };
+    }
+  }, []);
+
+  const load = useCallback(
+    (audioPath: string) => {
+      cleanup();
+      setError(null);
+      setIsLoading(true);
+      setIsPlaying(false);
+      setCurrentTime(0);
+      setDuration(0);
+
+      const audio = new Audio(audioPath);
+      audio.playbackRate = playbackRateRef.current;
+
+      // Create event handlers
+      const handleLoadedData = () => {
+        setIsLoading(false);
+        setDuration(audio.duration);
+      };
+
+      const handlePlay = () => {
+        setIsPlaying(true);
+      };
+
+      const handlePause = () => {
+        setIsPlaying(false);
+      };
+
+      const handleEnded = () => {
+        setIsPlaying(false);
+        setCurrentTime(0);
+      };
+
+      const handleTimeUpdate = () => {
+        setCurrentTime(audio.currentTime);
+      };
+
+      const handleError = () => {
+        setIsLoading(false);
+        setIsPlaying(false);
+        setError("Failed to load audio file. Please check the file path.");
+      };
+
+      // Store handler references for cleanup
+      handlersRef.current = {
+        loadeddata: handleLoadedData,
+        play: handlePlay,
+        pause: handlePause,
+        ended: handleEnded,
+        timeupdate: handleTimeUpdate,
+        error: handleError,
+      };
+
+      // Add event listeners
+      audio.addEventListener("loadeddata", handleLoadedData);
+      audio.addEventListener("play", handlePlay);
+      audio.addEventListener("pause", handlePause);
+      audio.addEventListener("ended", handleEnded);
+      audio.addEventListener("timeupdate", handleTimeUpdate);
+      audio.addEventListener("error", handleError);
+
+      audioRef.current = audio;
+    },
+    [cleanup],
+  );
+
+  const play = useCallback(() => {
+    if (!audioRef.current) return;
+    audioRef.current.currentTime = 0;
+    audioRef.current.play().catch(() => {
+      setError("Failed to play audio. Please try again.");
+    });
+  }, []);
+
+  const pause = useCallback(() => {
+    if (!audioRef.current) return;
+    audioRef.current.pause();
+  }, []);
+
+  const stop = useCallback(() => {
+    if (!audioRef.current) return;
+    audioRef.current.pause();
+    audioRef.current.currentTime = 0;
+    setIsPlaying(false);
+    setCurrentTime(0);
+  }, []);
+
+  const setPlaybackRate = useCallback((rate: number) => {
+    playbackRateRef.current = rate;
+    if (audioRef.current) {
+      audioRef.current.playbackRate = rate;
+    }
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cleanup();
+    };
+  }, [cleanup]);
+
+  return {
+    load,
+    play,
+    pause,
+    stop,
+    setPlaybackRate,
+    isPlaying,
+    isLoading,
+    error,
+    duration,
+    currentTime,
+  };
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -128,6 +128,22 @@ export function Home() {
               </span>
             </Card>
           </Link>
+
+          <Link to="/sound-changes" className="block group">
+            <Card className="border-t-4 border-t-indigo-500 h-full hover:shadow-elevated hover:-translate-y-1 transition-all">
+              <div className="text-4xl mb-4">🔊</div>
+              <h3 className="text-xl font-semibold text-text-primary mb-2">
+                Sound Changes
+              </h3>
+              <p className="text-sm text-text-secondary mb-4 leading-relaxed">
+                Master English sound changes: linking, elision, assimilation,
+                and more.
+              </p>
+              <span className="text-primary font-medium text-sm group-hover:underline">
+                Start Training →
+              </span>
+            </Card>
+          </Link>
         </div>
       </section>
 

--- a/frontend/src/pages/SoundChangeCategoryDetail.tsx
+++ b/frontend/src/pages/SoundChangeCategoryDetail.tsx
@@ -1,0 +1,139 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams, Link } from "react-router-dom";
+import { soundChangeApi } from "../services/api";
+import { Container, Card, Button } from "../components/ui";
+import type { SoundChangeCategory, SoundChangeExercise } from "../types";
+
+const difficultyColors: Record<string, string> = {
+  beginner: "bg-success/10 text-success",
+  intermediate: "bg-warning/10 text-warning",
+  advanced: "bg-error/10 text-error",
+};
+
+export function SoundChangeCategoryDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const [category, setCategory] = useState<
+    (SoundChangeCategory & { exercises: (SoundChangeExercise & { items: { id: string }[] })[] }) | null
+  >(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCategory = useCallback(async () => {
+    if (!slug) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { category: data } = await soundChangeApi.getCategoryBySlug(slug);
+      setCategory(data);
+    } catch (err) {
+      console.error("Error fetching category:", err);
+      setError("Failed to load category. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [slug]);
+
+  useEffect(() => {
+    fetchCategory();
+  }, [fetchCategory]);
+
+  if (loading) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <div className="text-text-muted animate-pulse">
+            Loading category...
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (error || !category) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h2 className="text-xl font-semibold text-error mb-4">
+            {error || "Category not found"}
+          </h2>
+          <div className="flex gap-4 justify-center">
+            <Button variant="primary" onClick={fetchCategory}>
+              Try Again
+            </Button>
+            <Link to="/sound-changes">
+              <Button variant="secondary">Back to Categories</Button>
+            </Link>
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="lg" className="py-10">
+      <header className="mb-8">
+        <Link
+          to="/sound-changes"
+          className="text-primary text-sm hover:underline mb-4 inline-block"
+        >
+          ← Back to Categories
+        </Link>
+        <h1 className="text-3xl font-bold text-text-primary mb-1">
+          {category.name}
+        </h1>
+        <p className="text-indigo-500 font-medium mb-3">{category.nameJa}</p>
+        {category.description && (
+          <p className="text-text-secondary max-w-2xl">{category.description}</p>
+        )}
+      </header>
+
+      <section>
+        <h2 className="text-xl font-semibold text-text-primary mb-6">
+          Exercises
+        </h2>
+
+        {category.exercises.length === 0 ? (
+          <Card className="text-center py-8">
+            <p className="text-text-muted">
+              No exercises available for this category yet.
+            </p>
+          </Card>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {category.exercises.map((exercise) => (
+              <Link
+                key={exercise.id}
+                to={`/sound-changes/practice/${exercise.id}`}
+                className="block group"
+              >
+                <Card className="h-full hover:shadow-elevated hover:-translate-y-1 transition-all">
+                  <div className="flex items-start justify-between mb-3">
+                    <h3 className="text-lg font-semibold text-text-primary">
+                      {exercise.title}
+                    </h3>
+                    <span
+                      className={`text-xs px-2 py-1 rounded-full font-medium ${difficultyColors[exercise.difficulty] || ""}`}
+                    >
+                      {exercise.difficulty}
+                    </span>
+                  </div>
+                  <p className="text-sm text-text-muted mb-4">
+                    {exercise.items?.length ?? 0} item
+                    {(exercise.items?.length ?? 0) !== 1 ? "s" : ""}
+                  </p>
+                  <span className="text-primary font-medium text-sm group-hover:underline">
+                    Start Practice →
+                  </span>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </Container>
+  );
+}
+
+export default SoundChangeCategoryDetail;

--- a/frontend/src/pages/SoundChangeHome.tsx
+++ b/frontend/src/pages/SoundChangeHome.tsx
@@ -1,0 +1,111 @@
+import { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { soundChangeApi } from "../services/api";
+import { Container, Card, Button } from "../components/ui";
+import type { SoundChangeCategory } from "../types";
+
+export function SoundChangeHome() {
+  const [categories, setCategories] = useState<SoundChangeCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCategories = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { categories: data } = await soundChangeApi.getCategories();
+      setCategories(data);
+    } catch (err) {
+      console.error("Error fetching categories:", err);
+      setError("Failed to load categories. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  if (loading) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <div className="text-text-muted animate-pulse">
+            Loading categories...
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h2 className="text-xl font-semibold text-error mb-4">{error}</h2>
+          <Button variant="primary" onClick={fetchCategories}>
+            Try Again
+          </Button>
+        </Card>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="lg" className="py-10">
+      <header className="text-center mb-10">
+        <h1 className="text-3xl font-bold text-text-primary mb-3">
+          Sound Changes
+        </h1>
+        <p className="text-text-secondary max-w-2xl mx-auto">
+          Master natural English pronunciation by practicing 8 types of sound
+          changes. Learn how words connect, change, and transform in real
+          speech.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {categories.map((category) => {
+          const exerciseCount = (category as unknown as { exercises?: { id: string }[] }).exercises?.length ?? 0;
+          return (
+            <Link
+              key={category.id}
+              to={`/sound-changes/${category.slug}`}
+              className="block group"
+            >
+              <Card className="border-t-4 border-t-indigo-500 h-full hover:shadow-elevated hover:-translate-y-1 transition-all">
+                <h3 className="text-lg font-semibold text-text-primary mb-1">
+                  {category.name}
+                </h3>
+                <p className="text-sm text-indigo-500 font-medium mb-3">
+                  {category.nameJa}
+                </p>
+                <p className="text-sm text-text-secondary mb-4 leading-relaxed line-clamp-3">
+                  {category.description}
+                </p>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-text-muted">
+                    {exerciseCount} exercise{exerciseCount !== 1 ? "s" : ""}
+                  </span>
+                  <span className="text-primary font-medium text-sm group-hover:underline">
+                    Practice →
+                  </span>
+                </div>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="mt-10 text-center">
+        <Link to="/">
+          <Button variant="secondary">Back to Home</Button>
+        </Link>
+      </div>
+    </Container>
+  );
+}
+
+export default SoundChangeHome;

--- a/frontend/src/pages/SoundChangePracticeSession.tsx
+++ b/frontend/src/pages/SoundChangePracticeSession.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams, Link } from "react-router-dom";
+import axios from "axios";
+import { soundChangeApi } from "../services/api";
+import { Container, Card, Button } from "../components/ui";
+import {
+  SoundChangePracticePlayer,
+  type PracticeSummary,
+} from "../components/SoundChangePracticePlayer";
+import type { SoundChangeExercise, SoundChangeExerciseItem } from "../types";
+
+type SessionState = "loading" | "ready" | "practicing" | "completed" | "error";
+
+export function SoundChangePracticeSession() {
+  const { exerciseId } = useParams<{ exerciseId: string }>();
+
+  const [exercise, setExercise] = useState<
+    (SoundChangeExercise & { items: SoundChangeExerciseItem[] }) | null
+  >(null);
+  const [sessionState, setSessionState] = useState<SessionState>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [summary, setSummary] = useState<PracticeSummary | null>(null);
+
+  const fetchExercise = useCallback(async () => {
+    if (!exerciseId) return;
+
+    setSessionState("loading");
+    setError(null);
+
+    try {
+      const { exercise: data } =
+        await soundChangeApi.getExerciseById(exerciseId);
+      setExercise(data);
+      setSessionState("ready");
+    } catch (err) {
+      console.error("Error fetching exercise:", err);
+
+      let errorMessage = "Failed to load exercise";
+      if (axios.isAxiosError(err)) {
+        if (err.response?.status === 404) {
+          errorMessage = "This exercise could not be found.";
+        } else if (err.response?.status && err.response.status >= 500) {
+          errorMessage = "Server error. Please try again.";
+        } else if (err.code === "ERR_NETWORK" || !err.response) {
+          errorMessage = "Network error. Please check your connection.";
+        }
+      }
+
+      setError(errorMessage);
+      setSessionState("error");
+    }
+  }, [exerciseId]);
+
+  useEffect(() => {
+    fetchExercise();
+  }, [fetchExercise]);
+
+  const handleStart = useCallback(() => {
+    setSessionState("practicing");
+  }, []);
+
+  const handleComplete = useCallback((practiceSummary: PracticeSummary) => {
+    setSummary(practiceSummary);
+    setSessionState("completed");
+  }, []);
+
+  const handlePracticeAgain = useCallback(() => {
+    setSummary(null);
+    setSessionState("ready");
+  }, []);
+
+  if (sessionState === "loading") {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <div className="text-text-muted animate-pulse">
+            Loading exercise...
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (sessionState === "error" || !exercise) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h2 className="text-xl font-semibold text-error mb-4">
+            {error || "Exercise not found"}
+          </h2>
+          <div className="flex gap-4 justify-center">
+            <Button variant="primary" onClick={fetchExercise}>
+              Try Again
+            </Button>
+            <Link to="/sound-changes">
+              <Button variant="secondary">Back to Categories</Button>
+            </Link>
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (exercise.items.length === 0) {
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h2 className="text-xl font-semibold text-text-primary mb-4">
+            No items in this exercise
+          </h2>
+          <Link to="/sound-changes">
+            <Button variant="secondary">Back to Categories</Button>
+          </Link>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (sessionState === "ready") {
+    const categoryName = exercise.category?.name || "Sound Change";
+    const categoryNameJa = exercise.category?.nameJa || "";
+    const categorySlug = exercise.category?.slug || "";
+
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h1 className="text-3xl font-bold text-text-primary mb-2">
+            {exercise.title}
+          </h1>
+          <p className="text-indigo-500 font-medium mb-6">
+            {categoryName} ({categoryNameJa})
+          </p>
+
+          <div className="bg-surface-elevated rounded-lg p-6 mb-8 max-w-md mx-auto">
+            <div className="space-y-2 text-left">
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Items:</span>
+                <span className="text-text-primary font-medium">
+                  {exercise.items.length}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Difficulty:</span>
+                <span className="text-text-primary font-medium capitalize">
+                  {exercise.difficulty}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Types:</span>
+                <span className="text-text-primary font-medium">
+                  Fill-blank & Dictation
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <Button
+              variant="primary"
+              size="lg"
+              className="w-full max-w-xs"
+              onClick={handleStart}
+            >
+              Start Practice
+            </Button>
+
+            <div>
+              <Link to={categorySlug ? `/sound-changes/${categorySlug}` : "/sound-changes"}>
+                <Button variant="secondary" size="sm">
+                  Back to Exercises
+                </Button>
+              </Link>
+            </div>
+          </div>
+
+          <div className="mt-8 text-text-muted text-sm">
+            <p>Tips:</p>
+            <ul className="list-disc list-inside text-left max-w-md mx-auto mt-2 space-y-1">
+              <li>Listen carefully to the audio</li>
+              <li>Pay attention to how words connect and change</li>
+              <li>For fill-blank: type the missing word(s)</li>
+              <li>For dictation: type the entire sentence</li>
+              <li>Use keyboard shortcuts for faster navigation</li>
+            </ul>
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  if (sessionState === "completed" && summary) {
+    const categorySlug = exercise.category?.slug || "";
+
+    return (
+      <Container size="lg" className="py-10">
+        <Card className="text-center py-12">
+          <h1 className="text-3xl font-bold text-text-primary mb-2">
+            Practice Complete!
+          </h1>
+          <p className="text-text-secondary mb-8">{exercise.title}</p>
+
+          <div className="bg-surface-elevated rounded-lg p-6 mb-8 max-w-md mx-auto">
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Your Results
+            </h2>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Total Items:</span>
+                <span className="text-text-primary font-medium">
+                  {summary.totalItems}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Perfect Answers:</span>
+                <span className="text-success font-medium">
+                  {summary.correctCount}
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Average Accuracy:</span>
+                <span
+                  className={`font-medium ${
+                    summary.averageAccuracy >= 90
+                      ? "text-success"
+                      : summary.averageAccuracy >= 70
+                        ? "text-warning"
+                        : "text-error"
+                  }`}
+                >
+                  {summary.averageAccuracy}%
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <p className="text-text-secondary mb-8">
+            {summary.averageAccuracy >= 90
+              ? "Excellent! You have a great ear for sound changes!"
+              : summary.averageAccuracy >= 70
+                ? "Good job! Keep practicing to sharpen your listening."
+                : "Keep going! Practice makes perfect."}
+          </p>
+
+          <div className="flex gap-4 justify-center flex-wrap">
+            <Button variant="primary" onClick={handlePracticeAgain}>
+              Practice Again
+            </Button>
+            <Link to={categorySlug ? `/sound-changes/${categorySlug}` : "/sound-changes"}>
+              <Button variant="secondary">Back to Exercises</Button>
+            </Link>
+          </div>
+        </Card>
+      </Container>
+    );
+  }
+
+  // Practicing state
+  const categorySlug = exercise.category?.slug || "";
+
+  return (
+    <Container size="lg" className="py-10">
+      <header className="mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-text-primary">
+              {exercise.title}
+            </h1>
+            <p className="text-text-secondary text-sm">
+              {exercise.category?.name} ({exercise.category?.nameJa})
+            </p>
+          </div>
+          <Link to={categorySlug ? `/sound-changes/${categorySlug}` : "/sound-changes"}>
+            <Button variant="secondary" size="sm">
+              Exit Practice
+            </Button>
+          </Link>
+        </div>
+      </header>
+
+      <SoundChangePracticePlayer
+        items={exercise.items}
+        onComplete={handleComplete}
+      />
+    </Container>
+  );
+}
+
+export default SoundChangePracticeSession;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -11,6 +11,11 @@ import type {
   ListeningPassage,
   ListeningProgress,
   ListeningProgressSummary,
+  SoundChangeCategory,
+  SoundChangeExercise,
+  SoundChangeExerciseItem,
+  SoundChangeProgress,
+  SoundChangeProgressSummary,
 } from "../types";
 
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3001/api";
@@ -274,6 +279,53 @@ export const listeningApi = {
   getSummary: async (userId: number = DEFAULT_USER_ID) => {
     const response = await api.get<ListeningProgressSummary>(
       `/listening/progress/summary?userId=${userId}`,
+    );
+    return response.data;
+  },
+};
+
+// Sound Changes API
+export const soundChangeApi = {
+  getCategories: async () => {
+    const response = await api.get<{ categories: SoundChangeCategory[] }>(
+      "/sound-changes/categories",
+    );
+    return response.data;
+  },
+
+  getCategoryBySlug: async (slug: string) => {
+    const response = await api.get<{
+      category: SoundChangeCategory & { exercises: (SoundChangeExercise & { items: { id: string }[] })[] };
+    }>(`/sound-changes/categories/${slug}`);
+    return response.data;
+  },
+
+  getExerciseById: async (exerciseId: string) => {
+    const response = await api.get<{
+      exercise: SoundChangeExercise & { items: SoundChangeExerciseItem[] };
+    }>(`/sound-changes/exercises/${exerciseId}`);
+    return response.data;
+  },
+
+  recordProgress: async (data: {
+    userId?: number;
+    itemId: string;
+    accuracy: number;
+    isCorrect: boolean;
+  }) => {
+    const response = await api.post<{ progress: SoundChangeProgress }>(
+      "/sound-changes/progress",
+      {
+        ...data,
+        userId: data.userId ?? DEFAULT_USER_ID,
+      },
+    );
+    return response.data;
+  },
+
+  getSummary: async (userId: number = DEFAULT_USER_ID) => {
+    const response = await api.get<SoundChangeProgressSummary>(
+      `/sound-changes/progress/summary?userId=${userId}`,
     );
     return response.data;
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -145,3 +145,67 @@ export interface ListeningProgressSummary {
   correctAnswers: number;
   accuracy: number;
 }
+
+// Sound Change types
+export interface SoundChangeCategory {
+  id: string;
+  name: string;
+  nameJa: string;
+  slug: string;
+  description: string | null;
+  order: number;
+  exercises?: SoundChangeExercise[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SoundChangeExercise {
+  id: string;
+  categoryId: string;
+  title: string;
+  difficulty: "beginner" | "intermediate" | "advanced";
+  order: number;
+  items?: SoundChangeExerciseItem[];
+  category?: Pick<SoundChangeCategory, "name" | "nameJa" | "slug">;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SoundChangeExerciseItem {
+  id: string;
+  exerciseId: string;
+  type: "fill_blank" | "dictation";
+  audioPath: string;
+  sentence: string;
+  blank: string | null;
+  blankIndex: number | null;
+  explanation: string | null;
+  order: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SoundChangeProgress {
+  id: string;
+  userId: number;
+  itemId: string;
+  accuracy: number;
+  isCorrect: boolean;
+  answeredAt: string;
+}
+
+export interface SoundChangeProgressSummary {
+  totalCategories: number;
+  totalItems: number;
+  answeredItems: number;
+  correctItems: number;
+  averageAccuracy: number;
+  byCategory: {
+    categoryId: string;
+    name: string;
+    totalExercises: number;
+    totalItems: number;
+    answeredItems: number;
+    averageAccuracy: number;
+  }[];
+}


### PR DESCRIPTION
## Summary
- Add Sound Change Listening Practice feature for learning 8 types of English sound changes
- Support fill-in-the-blank and full dictation exercise formats
- Include pre-recorded audio playback with adjustable speed
- Category-based organization with progress tracking

## Changes

### Backend
- Add Prisma models: SoundChangeCategory, SoundChangeExercise, SoundChangeExerciseItem, SoundChangeProgress
- Add API routes for categories, exercises, and progress tracking
- Add seed data for all 8 sound change categories with sample exercises

### Frontend
- Add `usePrerecordedAudio` hook for HTML5 audio playback with proper cleanup
- Add components: SoundChangeFillBlank, SoundChangeDictation, SoundChangePracticePlayer
- Add pages: SoundChangeHome (category grid), SoundChangeCategoryDetail (exercise list), SoundChangePracticeSession (practice flow)
- Add types and API service
- Add routes and navigation card on Home page

## Test plan
- [x] Backend tests pass (116 tests)
- [x] Frontend tests pass (236 tests)
- [x] Frontend build succeeds
- [ ] Manual testing: Navigate from Home → Sound Changes → Category → Practice Session
- [ ] Verify audio playback works with speed control
- [ ] Test fill-in-the-blank answer validation (case insensitive)
- [ ] Test dictation diff display with color-coded feedback

## Notes
- Audio files need to be manually placed in `frontend/public/audio/sound-changes/{category-slug}/` directory
- Seed data includes placeholder audio paths

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)